### PR TITLE
Unify parameter and improve error message

### DIFF
--- a/Configurability/ConfigurableServiceHelper.php
+++ b/Configurability/ConfigurableServiceHelper.php
@@ -30,7 +30,7 @@ class ConfigurableServiceHelper
     const CONF_MESSAGE = 'message';
     const CONF_RECOVERABLE = 'recoverable';
 
-    const CONF_NO_RESULTS = 'noResults';
+    const CONF_NO_RESULTS = 'no_results';
     const STEP_DEFINE = 'define';
 
     const STEP_VALIDATE = 'validate';
@@ -96,11 +96,13 @@ class ConfigurableServiceHelper
         return $context;
     }
 
-    public function resolveArray($input, &$context){
+    public function resolveArray($input, &$context)
+    {
         $output = [];
-        foreach($input as $key => $value){
-            $output[$key] = $this->resolve($value,$context);
+        foreach ($input as $key => $value) {
+            $output[$key] = $this->resolve($value, $context);
         }
+
         return $output;
     }
 
@@ -163,6 +165,7 @@ class ConfigurableServiceHelper
                 break;
             case self::STEP_VALIDATE:
                 $this->validate($stepActionParams, $context);
+
                 return true;
                 break;
             default:
@@ -196,7 +199,6 @@ class ConfigurableServiceHelper
 
     public function validate(array $stepConfig, array &$context)
     {
-
         $config = $this->validateResolver->resolve($stepConfig);
 
         $rule = $config[self::CONF_RULE];
@@ -206,7 +208,7 @@ class ConfigurableServiceHelper
         $display_message = $config[self::CONF_DISPLAY_MESSAGE];
 
         $evaluation = $this->resolve($rule, $context);
-        if ($evaluation !== true) {
+        if (true !== $evaluation) {
             $message = $this->resolve($message, $context);
             if ($no_results) {
                 throw new NoResultsException($message);

--- a/Tools/Mapper/Mapper.php
+++ b/Tools/Mapper/Mapper.php
@@ -42,7 +42,7 @@ class Mapper implements MapperInterface
      */
     public function formatDate($format, \DateTime $date = null)
     {
-        if ($date === null) {
+        if (null === $date) {
             return null;
         }
 
@@ -87,7 +87,7 @@ class Mapper implements MapperInterface
             foreach ($mapping as $key => $value) {
                 $resolved = $this->resolve($value, $obj, $context);
 
-                if ($resolved !== null) {
+                if (null !== $resolved) {
                     $res[$key] = $resolved;
                 }
             }
@@ -146,6 +146,10 @@ class Mapper implements MapperInterface
      */
     public function keyExists(array $obj, $key)
     {
+        if (!is_string($key) and !is_integer($key)) {
+            throw new \RuntimeException('keyExists expected either a string or an integer, \''.print_r($key, true).'\' was given.');
+        }
+
         return array_key_exists($key, $obj);
     }
 
@@ -302,11 +306,11 @@ class Mapper implements MapperInterface
     }
 
     /**
-     * Return the n-th section of the given string splitted by piece of the given length
+     * Return the n-th section of the given string splitted by piece of the given length.
      *
      * @param string $string
-     * @param int $length
-     * @param int $section
+     * @param int    $length
+     * @param int    $section
      *
      * @return string
      */
@@ -320,6 +324,7 @@ class Mapper implements MapperInterface
         if (isset($lines[$section])) {
             $result = $lines[$section];
         }
+
         return $result;
     }
 


### PR DESCRIPTION
- Explicit error message in the Mapper for keyExists function
- Unify parameter name for no_results instead of noResults