### PR TITLE
Add a logger to endpoint

### DIFF
--- a/Components/DB/DBConfigurableConsumer.php
+++ b/Components/DB/DBConfigurableConsumer.php
@@ -120,7 +120,8 @@ class DBConfigurableConsumer extends Service implements ConfigurableConsumerInte
 
                 $endpoint->handle($message);
 
-                $endpoint->getLogger()->info('A message was consumed on '.date('Y-m-d H:i:s'));
+                $now = \DateTime::createFromFormat('U.u', microtime(true));
+                $endpoint->getLogger()->info('A message was consumed on '.$now->format('Y-m-d H:i:s.u'));
 
                 $this->onConsume($endpoint, $message);
             }

--- a/Components/DB/DBConfigurableConsumer.php
+++ b/Components/DB/DBConfigurableConsumer.php
@@ -70,7 +70,7 @@ class DBConfigurableConsumer extends Service implements ConfigurableConsumerInte
             }
         }
 
-        if ($result == null) {
+        if (null == $result) {
             return null;
         } elseif (is_array($result)) {
             $result = new SerializableArray($result);
@@ -103,6 +103,11 @@ class DBConfigurableConsumer extends Service implements ConfigurableConsumerInte
         $this->configurableStepsProvider->executeSteps($steps, $options, $context);
     }
 
+    /**
+     * @param EndpointInterface $endpoint
+     *
+     * @return bool|void
+     */
     public function consume(EndpointInterface $endpoint)
     {
         while (!$this->shouldStop()) {
@@ -114,6 +119,8 @@ class DBConfigurableConsumer extends Service implements ConfigurableConsumerInte
                 --$this->expirationCount;
 
                 $endpoint->handle($message);
+
+                $endpoint->getLogger()->info('A message was consumed on '.date('Y-m-d H:i:s'));
 
                 $this->onConsume($endpoint, $message);
             }

--- a/Core/Consumers/AbstractConsumer.php
+++ b/Core/Consumers/AbstractConsumer.php
@@ -91,7 +91,8 @@ abstract class AbstractConsumer extends Service implements ConsumerInterface
 
                     $this->process($endpoint, $message);
 
-                    $endpoint->getLogger()->info('A message was consumed on '.date('Y-m-d H:i:s'));
+                    $now = \DateTime::createFromFormat('U.u', microtime(true));
+                    $endpoint->getLogger()->info('A message was consumed on '.$now->format('Y-m-d H:i:s.u'));
 
                     $this->confirmMessage($endpoint, $message);
                 }

--- a/Core/Consumers/AbstractConsumer.php
+++ b/Core/Consumers/AbstractConsumer.php
@@ -64,6 +64,9 @@ abstract class AbstractConsumer extends Service implements ConsumerInterface
      * This function is called to confirm that a message was successfully handled. Until this point, the message should
      * not be removed from the source Endpoint, this is very important to ensure the Message delivery guarantee.
      *
+     * @param EndpointInterface $endpoint
+     * @param MessageInterface  $message
+     *
      * @return MessageInterface
      */
     abstract protected function confirmMessage(EndpointInterface $endpoint, MessageInterface $message);
@@ -87,6 +90,8 @@ abstract class AbstractConsumer extends Service implements ConsumerInterface
                     --$this->expirationCount;
 
                     $this->process($endpoint, $message);
+
+                    $endpoint->getLogger()->info('A message was consumed on '.date('Y-m-d H:i:s'));
 
                     $this->confirmMessage($endpoint, $message);
                 }

--- a/Core/Endpoints/Endpoint.php
+++ b/Core/Endpoints/Endpoint.php
@@ -3,6 +3,8 @@
 namespace Smartbox\Integration\FrameworkBundle\Core\Endpoints;
 
 use JMS\Serializer\Annotation as JMS;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Smartbox\CoreBundle\Type\SerializableArray;
 use Smartbox\CoreBundle\Type\Traits\HasInternalType;
 use Smartbox\Integration\FrameworkBundle\Core\Consumers\ConsumerInterface;
@@ -44,6 +46,9 @@ class Endpoint implements EndpointInterface
     /** @var HandlerInterface */
     protected $handler = null;
 
+    /** @var LoggerInterface */
+    protected $logger = null;
+
     /**
      * {@inheritdoc}
      */
@@ -53,7 +58,8 @@ class Endpoint implements EndpointInterface
         ProtocolInterface $protocol,
         ProducerInterface $producer = null,
         ConsumerInterface $consumer = null,
-        HandlerInterface $handler = null
+        HandlerInterface $handler = null,
+        LoggerInterface $logger = null
     ) {
         $this->uri = $resolvedUri;
         $this->consumer = $consumer;
@@ -61,6 +67,11 @@ class Endpoint implements EndpointInterface
         $this->handler = $handler;
         $this->protocol = $protocol;
         $this->options = $options;
+        if (is_null($logger)) {
+            $this->logger = new NullLogger();
+        } else {
+            $this->logger = $logger;
+        }
     }
 
     /**
@@ -113,6 +124,14 @@ class Endpoint implements EndpointInterface
         }
 
         return $this->producer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLogger()
+    {
+        return $this->logger;
     }
 
     /**
@@ -179,7 +198,7 @@ class Endpoint implements EndpointInterface
      */
     public function isInOnly()
     {
-        return $this->getExchangePattern() == Protocol::EXCHANGE_PATTERN_IN_ONLY;
+        return Protocol::EXCHANGE_PATTERN_IN_ONLY == $this->getExchangePattern();
     }
 
     /**

--- a/Core/Endpoints/Endpoint.php
+++ b/Core/Endpoints/Endpoint.php
@@ -47,7 +47,7 @@ class Endpoint implements EndpointInterface
     protected $handler = null;
 
     /** @var LoggerInterface */
-    protected $logger = null;
+    protected $logger;
 
     /**
      * {@inheritdoc}
@@ -58,8 +58,7 @@ class Endpoint implements EndpointInterface
         ProtocolInterface $protocol,
         ProducerInterface $producer = null,
         ConsumerInterface $consumer = null,
-        HandlerInterface $handler = null,
-        LoggerInterface $logger = null
+        HandlerInterface $handler = null
     ) {
         $this->uri = $resolvedUri;
         $this->consumer = $consumer;
@@ -67,11 +66,27 @@ class Endpoint implements EndpointInterface
         $this->handler = $handler;
         $this->protocol = $protocol;
         $this->options = $options;
+
+        $this->setLogger(new NullLogger());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLogger()
+    {
+        return $this->logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLogger(LoggerInterface $logger = null)
+    {
         if (is_null($logger)) {
-            $this->logger = new NullLogger();
-        } else {
-            $this->logger = $logger;
+            $logger = new NullLogger();
         }
+        $this->logger = $logger;
     }
 
     /**
@@ -124,14 +139,6 @@ class Endpoint implements EndpointInterface
         }
 
         return $this->producer;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getLogger()
-    {
-        return $this->logger;
     }
 
     /**

--- a/Core/Endpoints/EndpointFactory.php
+++ b/Core/Endpoints/EndpointFactory.php
@@ -112,7 +112,8 @@ class EndpointFactory extends Service
         }
 
         // Create
-        $endpoint = new Endpoint($uri, $options, $protocol, $producer, $consumer, $handler, $logger);
+        $endpoint = new Endpoint($uri, $options, $protocol, $producer, $consumer, $handler);
+        $endpoint->setLogger($logger);
 
         // Cache
         $this->endpointsCache[$uri] = $endpoint;

--- a/Core/Endpoints/EndpointFactory.php
+++ b/Core/Endpoints/EndpointFactory.php
@@ -2,6 +2,7 @@
 
 namespace Smartbox\Integration\FrameworkBundle\Core\Endpoints;
 
+use Psr\Log\LoggerInterface;
 use Smartbox\Integration\FrameworkBundle\Configurability\ConfigurableInterface;
 use Smartbox\Integration\FrameworkBundle\Configurability\Routing\InternalRouterResourceNotFound;
 use Smartbox\Integration\FrameworkBundle\Core\Consumers\ConsumerInterface;
@@ -39,13 +40,13 @@ class EndpointFactory extends Service
     }
 
     /**
-     * @param string $uri
+     * @param string               $uri
+     * @param string               $mode
+     * @param LoggerInterface|null $logger
      *
-     * @return EndpointInterface
-     *
-     * @throws \Exception
+     * @return mixed|Endpoint
      */
-    public function createEndpoint($uri, $mode = self::MODE_PRODUCE)
+    public function createEndpoint($uri, $mode = self::MODE_PRODUCE, LoggerInterface $logger = null)
     {
         if (array_key_exists($uri, $this->endpointsCache)) {
             return $this->endpointsCache[$uri];
@@ -111,7 +112,7 @@ class EndpointFactory extends Service
         }
 
         // Create
-        $endpoint = new Endpoint($uri, $options, $protocol, $producer, $consumer, $handler);
+        $endpoint = new Endpoint($uri, $options, $protocol, $producer, $consumer, $handler, $logger);
 
         // Cache
         $this->endpointsCache[$uri] = $endpoint;
@@ -133,9 +134,10 @@ class EndpointFactory extends Service
 
     /**
      * @param $uri
-     * @param array $routeOptions
+     * @param array             $routeOptions
      * @param ProtocolInterface $protocol
-     * @param string $mode
+     * @param string            $mode
+     *
      * @return OptionsResolver
      */
     protected function getOptionsResolver($uri, array &$routeOptions, ProtocolInterface $protocol, $mode)
@@ -148,7 +150,7 @@ class EndpointFactory extends Service
         $handler = array_key_exists(Protocol::OPTION_HANDLER, $routeOptions) ? $routeOptions[Protocol::OPTION_HANDLER] : $protocol->getDefaultHandler();
 
         // Check Consumer
-        if ($mode == self::MODE_CONSUME && $consumer) {
+        if (self::MODE_CONSUME == $mode && $consumer) {
             if ($consumer instanceof ConsumerInterface) {
                 if ($consumer instanceof ConfigurableInterface) {
                     $consumer->configureOptionsResolver($optionsResolver);
@@ -163,7 +165,7 @@ class EndpointFactory extends Service
         }
 
         // Check Producer
-        if ($mode == self::MODE_PRODUCE && $producer) {
+        if (self::MODE_PRODUCE == $mode && $producer) {
             if ($producer instanceof ProducerInterface) {
                 if ($producer instanceof ConfigurableInterface) {
                     $producer->configureOptionsResolver($optionsResolver);
@@ -197,6 +199,12 @@ class EndpointFactory extends Service
         return $optionsResolver;
     }
 
+    /**
+     * @param Exchange $exchange
+     * @param string   $uri
+     *
+     * @return mixed
+     */
     public static function resolveURIParams(Exchange $exchange, $uri)
     {
         preg_match_all('/\\{([^{}]+)\\}/', $uri, $matches);

--- a/Core/Endpoints/EndpointInterface.php
+++ b/Core/Endpoints/EndpointInterface.php
@@ -2,6 +2,7 @@
 
 namespace Smartbox\Integration\FrameworkBundle\Core\Endpoints;
 
+use Psr\Log\LoggerInterface;
 use Smartbox\CoreBundle\Type\SerializableInterface;
 use Smartbox\Integration\FrameworkBundle\Core\Consumers\ConsumerInterface;
 use Smartbox\Integration\FrameworkBundle\Core\Exchange;
@@ -17,11 +18,12 @@ interface EndpointInterface extends SerializableInterface
 {
     /**
      * @param $resolvedUri
-     * @param array             $resolvedOptions
-     * @param ProtocolInterface $protocol
-     * @param ProducerInterface $producer
-     * @param ConsumerInterface $consumer
-     * @param HandlerInterface  $handler
+     * @param array                $resolvedOptions
+     * @param ProtocolInterface    $protocol
+     * @param ProducerInterface    $producer
+     * @param ConsumerInterface    $consumer
+     * @param HandlerInterface     $handler
+     * @param LoggerInterface|null $logger
      */
     public function __construct(
         $resolvedUri,
@@ -29,7 +31,8 @@ interface EndpointInterface extends SerializableInterface
         ProtocolInterface $protocol,
         ProducerInterface $producer = null,
         ConsumerInterface $consumer = null,
-        HandlerInterface $handler = null
+        HandlerInterface $handler = null,
+        LoggerInterface $logger = null
     );
 
     /**
@@ -60,6 +63,11 @@ interface EndpointInterface extends SerializableInterface
     public function getProducer();
 
     /**
+     * @return LoggerInterface
+     */
+    public function getLogger();
+
+    /**
      * Consumes $maxAmount of messages, if $maxAmount is 0, then it consumes indefinitely in a loop.
      *
      * @param int $maxAmount
@@ -67,6 +75,8 @@ interface EndpointInterface extends SerializableInterface
     public function consume($maxAmount = 0);
 
     /**
+     * @param Exchange $exchange
+     *
      * @return bool
      */
     public function produce(Exchange $exchange);

--- a/Core/Endpoints/EndpointInterface.php
+++ b/Core/Endpoints/EndpointInterface.php
@@ -18,12 +18,11 @@ interface EndpointInterface extends SerializableInterface
 {
     /**
      * @param $resolvedUri
-     * @param array                $resolvedOptions
-     * @param ProtocolInterface    $protocol
-     * @param ProducerInterface    $producer
-     * @param ConsumerInterface    $consumer
-     * @param HandlerInterface     $handler
-     * @param LoggerInterface|null $logger
+     * @param array             $resolvedOptions
+     * @param ProtocolInterface $protocol
+     * @param ProducerInterface $producer
+     * @param ConsumerInterface $consumer
+     * @param HandlerInterface  $handler
      */
     public function __construct(
         $resolvedUri,
@@ -31,9 +30,20 @@ interface EndpointInterface extends SerializableInterface
         ProtocolInterface $protocol,
         ProducerInterface $producer = null,
         ConsumerInterface $consumer = null,
-        HandlerInterface $handler = null,
-        LoggerInterface $logger = null
+        HandlerInterface $handler = null
     );
+
+    /**
+     * @return LoggerInterface
+     */
+    public function getLogger();
+
+    /**
+     * @param null|LoggerInterface $logger
+     *
+     * @return mixed
+     */
+    public function setLogger(LoggerInterface $logger);
 
     /**
      * Returns the resolved URI.
@@ -61,11 +71,6 @@ interface EndpointInterface extends SerializableInterface
      * @return ProducerInterface
      */
     public function getProducer();
-
-    /**
-     * @return LoggerInterface
-     */
-    public function getLogger();
 
     /**
      * Consumes $maxAmount of messages, if $maxAmount is 0, then it consumes indefinitely in a loop.

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -25,6 +25,8 @@ parameters:
   smartesb.steps_provider.nosql.class: Smartbox\Integration\FrameworkBundle\Components\DB\NoSQL\NoSQLStepsProvider
   smartesb.steps_provider.csv.class: Smartbox\Integration\FrameworkBundle\Components\FileService\Csv\CsvConfigurableStepsProvider
 
+  smartesb.command.consumer.start.class: Smartbox\Integration\FrameworkBundle\Command\ConsumeCommand
+
 services:
   smartesb.serialization.handler.mongodate:
       class: '%smartesb.serialization.handler.mongodate.class%'
@@ -108,3 +110,10 @@ services:
 
   smartesb.handlers.async:
       class: '%smartesb.handlers.message_routing.class%'
+
+  # COMMANDS
+  smartesb.command.consumer.start:
+      class: '%smartesb.command.consumer.start.class%'
+      arguments: ['@smartesb.endpoint_factory']
+      tags:
+        -  { name: console.command }

--- a/Tests/Command/ConsumeCommandTest.php
+++ b/Tests/Command/ConsumeCommandTest.php
@@ -4,6 +4,7 @@ namespace Smartbox\FrameworkBundle\Tests\Command;
 
 use Smartbox\Integration\FrameworkBundle\Command\ConsumeCommand;
 use Smartbox\Integration\FrameworkBundle\Components\Queues\QueueConsumer;
+use Smartbox\Integration\FrameworkBundle\Core\Endpoints\EndpointFactory;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -14,6 +15,9 @@ class ConsumeCommandTest extends KernelTestCase
     const URI = 'queue://main/api';
 
     protected $mockConsumer;
+
+    /** @var EndpointFactory $endpointFactory */
+    protected $endpointFactory;
 
     public function setMockConsumer($expirationCount)
     {
@@ -30,7 +34,8 @@ class ConsumeCommandTest extends KernelTestCase
             ->method('consume')
             ->willReturn(true);
 
-        self::$kernel->getContainer()->set('smartesb.consumers.queue',$this->mockConsumer);
+        self::$kernel->getContainer()->set('smartesb.consumers.queue', $this->mockConsumer);
+        $this->endpointFactory = self::$kernel->getContainer()->get('smartesb.endpoint_factory');
     }
 
     public function testExecuteWithKillAfter()
@@ -38,13 +43,13 @@ class ConsumeCommandTest extends KernelTestCase
         $this->setMockConsumer(self::NB_MESSAGES);
 
         $application = new Application(self::$kernel);
-        $application->add(new ConsumeCommand());
+        $application->add(new ConsumeCommand($this->endpointFactory));
 
         $command = $application->find('smartesb:consumer:start');
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(array(
-            'command'  => $command->getName(),
+            'command' => $command->getName(),
             'uri' => self::URI, // argument
             '--killAfter' => self::NB_MESSAGES, // option
         ));
@@ -59,12 +64,12 @@ class ConsumeCommandTest extends KernelTestCase
         $this->setMockConsumer(0);
 
         $application = new Application(self::$kernel);
-        $application->add(new ConsumeCommand());
+        $application->add(new ConsumeCommand($this->endpointFactory));
 
         $command = $application->find('smartesb:consumer:start');
         $commandTester = new CommandTester($command);
         $commandTester->execute(array(
-            'command'  => $command->getName(),
+            'command' => $command->getName(),
             'uri' => self::URI, // argument
         ));
 


### PR DESCRIPTION
A logger was added to the endpointFactory.
When using verbose mode from the smartesb:consumer:start command, we can display each time a message is consumed.
The endpointFactory that is used in this command in now injected in the associated service.