### PR TITLE
Removed the use of getContainer in ConsumerCommand

### DIFF
--- a/Command/ConsumeCommand.php
+++ b/Command/ConsumeCommand.php
@@ -25,14 +25,28 @@ class ConsumeCommand extends ContainerAwareCommand
     /** @var InputInterface */
     protected $input;
 
+    /** @var EndpointFactory */
+    protected $endpointFactory;
+
     /**
-     * @return \Smartbox\Integration\FrameworkBundle\Core\Endpoints\EndpointInterface
+     * ConsumeCommand constructor.
+     *
+     * @param EndpointFactory $endpointFactory
+     */
+    public function __construct(EndpointFactory $endpointFactory)
+    {
+        parent::__construct();
+        $this->endpointFactory = $endpointFactory;
+    }
+
+    /**
+     * @return mixed|\Smartbox\Integration\FrameworkBundle\Core\Endpoints\Endpoint
      */
     protected function getSourceEndpoint()
     {
         $uri = $this->getInput()->getArgument('uri');
 
-        return $this->getContainer()->get('smartesb.endpoint_factory')->createEndpoint($uri, EndpointFactory::MODE_CONSUME);
+        return $this->endpointFactory->createEndpoint($uri, EndpointFactory::MODE_CONSUME);
     }
 
     /**

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -25,6 +25,8 @@ parameters:
   smartesb.steps_provider.nosql.class: Smartbox\Integration\FrameworkBundle\Components\DB\NoSQL\NoSQLStepsProvider
   smartesb.steps_provider.csv.class: Smartbox\Integration\FrameworkBundle\Components\FileService\Csv\CsvConfigurableStepsProvider
 
+  smartesb.command.consumer.start.class: Smartbox\Integration\FrameworkBundle\Command\ConsumeCommand
+
 services:
   smartesb.serialization.handler.mongodate:
       class: '%smartesb.serialization.handler.mongodate.class%'
@@ -108,3 +110,10 @@ services:
 
   smartesb.handlers.async:
       class: '%smartesb.handlers.message_routing.class%'
+
+  # COMMANDS
+  smartesb.command.consumer.start:
+      class: '%smartesb.command.consumer.start.class%'
+      arguments: ['@smartesb.endpoint_factory']
+      tags:
+        -  { name: console.command }

--- a/Tests/Command/ConsumeCommandTest.php
+++ b/Tests/Command/ConsumeCommandTest.php
@@ -4,6 +4,7 @@ namespace Smartbox\FrameworkBundle\Tests\Command;
 
 use Smartbox\Integration\FrameworkBundle\Command\ConsumeCommand;
 use Smartbox\Integration\FrameworkBundle\Components\Queues\QueueConsumer;
+use Smartbox\Integration\FrameworkBundle\Core\Endpoints\EndpointFactory;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -14,6 +15,9 @@ class ConsumeCommandTest extends KernelTestCase
     const URI = 'queue://main/api';
 
     protected $mockConsumer;
+
+    /** @var EndpointFactory $endpointFactory */
+    protected $endpointFactory;
 
     public function setMockConsumer($expirationCount)
     {
@@ -31,6 +35,7 @@ class ConsumeCommandTest extends KernelTestCase
             ->willReturn(true);
 
         self::$kernel->getContainer()->set('smartesb.consumers.queue', $this->mockConsumer);
+        $this->endpointFactory = self::$kernel->getContainer()->get('smartesb.endpoint_factory');
     }
 
     public function testExecuteWithKillAfter()
@@ -38,7 +43,7 @@ class ConsumeCommandTest extends KernelTestCase
         $this->setMockConsumer(self::NB_MESSAGES);
 
         $application = new Application(self::$kernel);
-        $application->add(new ConsumeCommand());
+        $application->add(new ConsumeCommand($this->endpointFactory));
 
         $command = $application->find('smartesb:consumer:start');
 
@@ -59,7 +64,7 @@ class ConsumeCommandTest extends KernelTestCase
         $this->setMockConsumer(0);
 
         $application = new Application(self::$kernel);
-        $application->add(new ConsumeCommand());
+        $application->add(new ConsumeCommand($this->endpointFactory));
 
         $command = $application->find('smartesb:consumer:start');
         $commandTester = new CommandTester($command);


### PR DESCRIPTION
Using getContainer in a Symfony command is not recommended, especially because of Symfony 3. And also to make it much easier to test the command using dependency injection.