### PR TITLE
Allowing the response exception message to be the original one

### DIFF
--- a/Components/WebService/AbstractWebServiceProducer.php
+++ b/Components/WebService/AbstractWebServiceProducer.php
@@ -18,8 +18,11 @@ abstract class AbstractWebServiceProducer extends AbstractConfigurableProducer
     const OUTPUT_OBJECT = 'object';
     const OUTPUT_GROUP = 'group';
     const OUTPUT_DISPLAY_ERROR = 'display_error';
-    const HTTP_HEADER_TRANSACTION_ID ='X-Transaction-Id';
-    const HTTP_HEADER_EAI_TIMESTAMP ='X-Eai-Timestamp';
+    const HTTP_HEADER_TRANSACTION_ID = 'X-Transaction-Id';
+    const HTTP_HEADER_EAI_TIMESTAMP = 'X-Eai-Timestamp';
+    const DISPLAY_RESPONSE_ERROR = 'display_error';
+
+    private $displayResponseError = false;
 
     /**
      * @param $stepActionParams
@@ -32,7 +35,7 @@ abstract class AbstractWebServiceProducer extends AbstractConfigurableProducer
     {
         if (!is_array($stepActionParams)) {
             throw new InvalidConfigurationException(
-                "Step '" . self::STEP_VALIDATE_OBJECT_OUTPUT . "' in AbstractConfigurableProducer expected an array as configuration"
+                "Step '".self::STEP_VALIDATE_OBJECT_OUTPUT."' in AbstractConfigurableProducer expected an array as configuration"
             );
         }
 
@@ -82,5 +85,21 @@ abstract class AbstractWebServiceProducer extends AbstractConfigurableProducer
         }
 
         return false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getDisplayResponseError()
+    {
+        return $this->displayResponseError;
+    }
+
+    /**
+     * @param bool $displayResponseError
+     */
+    public function setDisplayResponseError($params, $context)
+    {
+        $this->displayResponseError = $this->confHelper->resolve($params[self::DISPLAY_RESPONSE_ERROR], $context);
     }
 }

--- a/Components/WebService/Exception/ExternalSystemException.php
+++ b/Components/WebService/Exception/ExternalSystemException.php
@@ -26,10 +26,14 @@ class ExternalSystemException extends \Exception implements ExternalSystemExcept
     public static function createFromException(ExternalSystemExceptionInterface $originalException)
     {
         $message = sprintf(self::EXCEPTION_MESSAGE_TEMPLATE, $originalException->getExternalSystemName());
+        $code = $originalException->getCode();
         if ($originalException->mustShowExternalSystemErrorMessage()) {
-            $message .= ': '.$originalException->getMessage();
+            $message = $originalException->getOriginalMessage();
+            $code = $originalException->getOriginalCode();
         }
-        $exception = new self($message);
+
+        $exception = new self($message, $code);
+
         $exception->setOriginalException($originalException);
 
         return $exception;

--- a/Components/WebService/Exception/ExternalSystemExceptionInterface.php
+++ b/Components/WebService/Exception/ExternalSystemExceptionInterface.php
@@ -20,4 +20,14 @@ interface ExternalSystemExceptionInterface
      * @return bool
      */
     public function mustShowExternalSystemErrorMessage();
+
+    /**
+     * @return mixed
+     */
+    public function getOriginalMessage();
+
+    /**
+     * @return mixed
+     */
+    public function getOriginalCode();
 }

--- a/Components/WebService/HasShowExternalSystemErrorMessage.php
+++ b/Components/WebService/HasShowExternalSystemErrorMessage.php
@@ -11,6 +11,16 @@ trait HasShowExternalSystemErrorMessage
     protected $showExternalSystemErrorMessage = false;
 
     /**
+     * @var
+     */
+    protected $originalMessage;
+
+    /**
+     * @var
+     */
+    protected $originalCode;
+
+    /**
      * @return bool
      */
     public function mustShowExternalSystemErrorMessage()
@@ -25,4 +35,21 @@ trait HasShowExternalSystemErrorMessage
     {
         $this->showExternalSystemErrorMessage = (bool) $showExternalSystemErrorMessage;
     }
+
+    /**
+     * @return mixed
+     */
+    public function getOriginalMessage()
+    {
+        return $this->originalMessage;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getOriginalCode()
+    {
+        return $this->originalCode;
+    }
+
 }

--- a/Components/WebService/HasShowExternalSystemErrorMessage.php
+++ b/Components/WebService/HasShowExternalSystemErrorMessage.php
@@ -52,4 +52,23 @@ trait HasShowExternalSystemErrorMessage
         return $this->originalCode;
     }
 
+    /**
+     * @param mixed $originalMessage
+     * @return HasShowExternalSystemErrorMessage
+     */
+    public function setOriginalMessage($originalMessage)
+    {
+        $this->originalMessage = $originalMessage;
+        return $this;
+    }
+
+    /**
+     * @param mixed $originalCode
+     * @return HasShowExternalSystemErrorMessage
+     */
+    public function setOriginalCode($originalCode)
+    {
+        $this->originalCode = $originalCode;
+        return $this;
+    }
 }

--- a/Components/WebService/Rest/Exceptions/RestException.php
+++ b/Components/WebService/Rest/Exceptions/RestException.php
@@ -91,6 +91,9 @@ class RestException extends \Exception implements SerializableInterface, Externa
         $this->responseHttpHeaders = $responseHeaders;
         $this->responseHttpBody = $responseBody;
         $this->responseStatusCode = $responseStatusCode;
+
+        $this->originalCode = $code;
+        $this->originalMessage = json_decode($this->responseHttpBody, true)['message'];
     }
 
     /**

--- a/Components/WebService/Rest/RestConfigurableProducer.php
+++ b/Components/WebService/Rest/RestConfigurableProducer.php
@@ -59,7 +59,7 @@ class RestConfigurableProducer extends AbstractWebServiceProducer
         ];
 
         $auth = $endpointOptions[RestConfigurableProtocol::OPTION_AUTH];
-        if (RestConfigurableProtocol::AUTH_BASIC === $auth) {
+        if ($auth === RestConfigurableProtocol::AUTH_BASIC) {
             $result['auth'] = [
                 $endpointOptions[Protocol::OPTION_USERNAME],
                 $endpointOptions[Protocol::OPTION_PASSWORD],

--- a/Components/WebService/Rest/RestConfigurableProducer.php
+++ b/Components/WebService/Rest/RestConfigurableProducer.php
@@ -16,7 +16,6 @@ use Smartbox\Integration\FrameworkBundle\Components\WebService\ConfigurableWebse
 use Smartbox\Integration\FrameworkBundle\Components\WebService\Exception\ExternalSystemExceptionInterface;
 use Smartbox\Integration\FrameworkBundle\Components\WebService\Rest\Exceptions\RecoverableRestException;
 use Smartbox\Integration\FrameworkBundle\Components\WebService\Rest\Exceptions\UnrecoverableRestException;
-use Smartbox\Integration\FrameworkBundle\Core\Processors\EndpointProcessor;
 use Smartbox\Integration\FrameworkBundle\Core\Protocols\Protocol;
 use Smartbox\Integration\FrameworkBundle\DependencyInjection\Traits\UsesGuzzleHttpClient;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -41,7 +40,6 @@ class RestConfigurableProducer extends AbstractWebServiceProducer
     const VALIDATION_DISPLAY_MESSAGE = 'display_message';
     const VALIDATION_RECOVERABLE = 'recoverable';
     const REQUEST_EXPECTED_RESPONSE_TYPE = 'response_type';
-    const RESPONSE_DISPLAY_ERROR = 'display_error';
 
     /**
      * @param       $options
@@ -61,7 +59,7 @@ class RestConfigurableProducer extends AbstractWebServiceProducer
         ];
 
         $auth = $endpointOptions[RestConfigurableProtocol::OPTION_AUTH];
-        if ($auth === RestConfigurableProtocol::AUTH_BASIC) {
+        if (RestConfigurableProtocol::AUTH_BASIC === $auth) {
             $result['auth'] = [
                 $endpointOptions[Protocol::OPTION_USERNAME],
                 $endpointOptions[Protocol::OPTION_PASSWORD],
@@ -116,12 +114,12 @@ class RestConfigurableProducer extends AbstractWebServiceProducer
             self::REQUEST_URI,
         ]);
 
-        $stepParamsResolver->setDefault(self::RESPONSE_DISPLAY_ERROR, false);
+        $stepParamsResolver->setDefault(self::DISPLAY_RESPONSE_ERROR, false);
         $stepParamsResolver->setDefault(self::REQUEST_EXPECTED_RESPONSE_TYPE, 'array');
         $stepParamsResolver->setDefined([
             RestConfigurableProtocol::OPTION_HEADERS,
             self::VALIDATION,
-            self::REQUEST_QUERY_PARAMETERS
+            self::REQUEST_QUERY_PARAMETERS,
         ]);
 
         $stepParamsResolver->setAllowedValues(self::REQUEST_HTTP_VERB, ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']);
@@ -160,7 +158,7 @@ class RestConfigurableProducer extends AbstractWebServiceProducer
         $endpointOptions = $this->confHelper->resolve($endpointOptions, $context);
 
         $requestHeaders = isset($params[RestConfigurableProtocol::OPTION_HEADERS]) ?
-            $this->confHelper->resolve($params[RestConfigurableProtocol::OPTION_HEADERS], $context):
+            $this->confHelper->resolve($params[RestConfigurableProtocol::OPTION_HEADERS], $context) :
             []
         ;
 
@@ -171,13 +169,13 @@ class RestConfigurableProducer extends AbstractWebServiceProducer
         $encoding = $endpointOptions[RestConfigurableProtocol::OPTION_ENCODING];
 
         $body = $this->confHelper->resolve($params[self::REQUEST_BODY], $context);
-        $requestBody = "";
+        $requestBody = '';
         if ($body) {
             $requestBody = $this->encodeRequestBody($encoding, $body);
         }
         $restOptions['body'] = $requestBody;
 
-        if ($httpMethod == "GET") {
+        if ('GET' == $httpMethod) {
             $queryParameters = $this->confHelper->resolve($params[self::REQUEST_QUERY_PARAMETERS], $context);
             if (!$queryParameters) {
                 throw new InvalidConfigurationException(
@@ -191,7 +189,6 @@ class RestConfigurableProducer extends AbstractWebServiceProducer
             $requestHeaders[self::HTTP_HEADER_TRANSACTION_ID] = $context['msg']->getContext()['transaction_id'];
             $requestHeaders[self::HTTP_HEADER_EAI_TIMESTAMP] = $context['msg']->getContext()['timestamp'];
         } catch (\Exception $e) {
-
         }
         /* @var Response $response */
         $request = new Request($httpMethod, $resolvedURI, $requestHeaders);
@@ -199,7 +196,7 @@ class RestConfigurableProducer extends AbstractWebServiceProducer
         try {
             $response = $client->send($request, $restOptions);
             $responseContent = $response->getBody()->getContents();
-            $this->getEventDispatcher()->dispatch(ExternalSystemHTTPEvent::EVENT_NAME, $this->getExternalSystemHTTPEvent($context,$request,$requestBody,$response,$responseContent,$endpointOptions));
+            $this->getEventDispatcher()->dispatch(ExternalSystemHTTPEvent::EVENT_NAME, $this->getExternalSystemHTTPEvent($context, $request, $requestBody, $response, $responseContent, $endpointOptions));
             // Tries to parse the body and convert it into an object
             $responseBody = null;
             if ($responseContent) {
@@ -232,9 +229,9 @@ class RestConfigurableProducer extends AbstractWebServiceProducer
                         true === $validationStep[self::VALIDATION_DISPLAY_MESSAGE]
                     );
                     if ($recoverable) {
-                        $this->throwRecoverableRestProducerException($message, $request->getHeaders(),$requestBody, $response->getHeaders(), $responseBody, $response->getStatusCode(), $showMessage);
+                        $this->throwRecoverableRestProducerException($message, $request->getHeaders(), $requestBody, $response->getHeaders(), $responseBody, $response->getStatusCode(), $showMessage);
                     } else {
-                        $this->throwUnrecoverableRestProducerException($message, $request->getHeaders(),$requestBody, $response->getHeaders(), $responseBody, $response->getStatusCode(), $showMessage);
+                        $this->throwUnrecoverableRestProducerException($message, $request->getHeaders(), $requestBody, $response->getHeaders(), $responseBody, $response->getStatusCode(), $showMessage);
                     }
                 }
             }
@@ -255,25 +252,18 @@ class RestConfigurableProducer extends AbstractWebServiceProducer
                 $responseBody = $response->getBody()->getContents();
                 $responseHeaders = $response->getHeaders();
                 $statusCode = $response->getStatusCode();
-            }else{
+            } else {
                 $responseBody = 'No response found';
                 $responseHeaders = [];
                 $statusCode = 0;
             }
 
-            //SIEAI-2089
-            $errorMessageResolver = new OptionsResolver();
-
-            $errorMessageResolver->setDefault(self::RESPONSE_DISPLAY_ERROR, false);
-
-            $params = $errorMessageResolver->resolve(array(self::RESPONSE_DISPLAY_ERROR => $stepActionParams[self::RESPONSE_DISPLAY_ERROR]));
-
-            $exposeErrorMessage = $this->confHelper->resolve($params[self::RESPONSE_DISPLAY_ERROR], $context);
+            $this->setDisplayResponseError($params, $context);
 
             if ($statusCode >= 400 && $statusCode <= 499) {
-                $this->throwUnrecoverableRestProducerException($e->getMessage(), $request->getHeaders(),$requestBody, $responseHeaders, $responseBody, $statusCode, $exposeErrorMessage, $e->getCode(), $e);
+                $this->throwUnrecoverableRestProducerException($e->getMessage(), $request->getHeaders(), $requestBody, $responseHeaders, $responseBody, $statusCode, $this->getDisplayResponseError(), $e->getCode(), $e);
             } else {
-                $this->throwRecoverableRestProducerException($e->getMessage(), $request->getHeaders(),$requestBody, $responseHeaders, $responseBody, $statusCode, $exposeErrorMessage, $e->getCode(), $e);
+                $this->throwRecoverableRestProducerException($e->getMessage(), $request->getHeaders(), $requestBody, $responseHeaders, $responseBody, $statusCode, $this->getDisplayResponseError(), $e->getCode(), $e);
             }
         } catch (UnrecoverableRestException $e) {
             throw $e;
@@ -282,12 +272,12 @@ class RestConfigurableProducer extends AbstractWebServiceProducer
                 $response->getBody()->rewind();
                 $responseBody = $response->getBody()->getContents();
                 $responseHeaders = $response->getHeaders();
-            }else{
+            } else {
                 $responseBody = 'No response found';
                 $responseHeaders = [];
             }
             $showMessage = ($e instanceof ExternalSystemExceptionInterface && $e->mustShowExternalSystemErrorMessage());
-            $this->throwRecoverableRestProducerException($e->getMessage(), $request->getHeaders(),$requestBody, $responseHeaders, $responseBody, $response ? $response->getStatusCode() : 0, $showMessage ,$e->getCode(), $e);
+            $this->throwRecoverableRestProducerException($e->getMessage(), $request->getHeaders(), $requestBody, $responseHeaders, $responseBody, $response ? $response->getStatusCode() : 0, $showMessage, $e->getCode(), $e);
         }
     }
 
@@ -304,14 +294,15 @@ class RestConfigurableProducer extends AbstractWebServiceProducer
 
     /**
      * @param $message
-     * @param array $requestHeaders
-     * @param string $requestBody
-     * @param array $responseHeaders
-     * @param string $responseBody
-     * @param int $responseStatusCode
-     * @param boolean $showMessage
-     * @param int $code
+     * @param array      $requestHeaders
+     * @param string     $requestBody
+     * @param array      $responseHeaders
+     * @param string     $responseBody
+     * @param int        $responseStatusCode
+     * @param bool       $showMessage
+     * @param int        $code
      * @param \Exception $previous
+     *
      * @throws RecoverableRestException
      */
     public function throwRecoverableRestProducerException(
@@ -333,14 +324,15 @@ class RestConfigurableProducer extends AbstractWebServiceProducer
 
     /**
      * @param $message
-     * @param array $requestHeaders
-     * @param string $requestBody
-     * @param array $responseHeaders
-     * @param string $responseBody
-     * @param int $responseStatusCode
-     * @param boolean $showMessage
-     * @param int $code
+     * @param array      $requestHeaders
+     * @param string     $requestBody
+     * @param array      $responseHeaders
+     * @param string     $responseBody
+     * @param int        $responseStatusCode
+     * @param bool       $showMessage
+     * @param int        $code
      * @param \Exception $previous
+     *
      * @throws UnrecoverableRestException
      */
     public function throwUnrecoverableRestProducerException(
@@ -360,24 +352,23 @@ class RestConfigurableProducer extends AbstractWebServiceProducer
         throw $exception;
     }
 
-    public function getExternalSystemHTTPEvent($context, RequestInterface $request,$requestBody,ResponseInterface $response, $restClientResponse,$endpointOptions)
+    public function getExternalSystemHTTPEvent($context, RequestInterface $request, $requestBody, ResponseInterface $response, $restClientResponse, $endpointOptions)
     {
         $event = new ExternalSystemHTTPEvent();
-        $event->setEventDetails( 'HTTP REST Request/Response Event' );
+        $event->setEventDetails('HTTP REST Request/Response Event');
         $event->setTimestampToCurrent();
         $event->setHttpURI($request->getUri()->__toString());
-        $event->setRequestHttpHeaders( $request->getHeaders() );
-        $event->setResponseHttpHeaders( $response->getHeaders() );
+        $event->setRequestHttpHeaders($request->getHeaders());
+        $event->setResponseHttpHeaders($response->getHeaders());
         $event->setFromUri($context['msg']->getContext()['from']);
-        $event->setExchangeId( $context['exchange']->getId() );
+        $event->setExchangeId($context['exchange']->getId());
         $event->setTransactionId($context['msg']->getContext()['transaction_id']);
         $event->setResponseHttpBody($restClientResponse);
         $event->setRequestHttpBody($requestBody);
 
-        if( $response->getStatusCode() === 200 )
-        {
-            $event->setStatus( 'Success' );
-        }else{
+        if (200 === $response->getStatusCode()) {
+            $event->setStatus('Success');
+        } else {
             $event->setStatus('Error');
         }
 

--- a/Components/WebService/Soap/Exceptions/SoapException.php
+++ b/Components/WebService/Soap/Exceptions/SoapException.php
@@ -79,6 +79,8 @@ class SoapException extends \Exception implements SerializableInterface, Externa
         $this->request = $request;
         $this->responseHeaders = $responseHeaders;
         $this->response = $response;
+        $this->originalMessage = $previous->faultstring;
+        $this->originalCode = $previous->faultcode;
     }
 
     /**

--- a/Configurability/ConfigurableServiceHelper.php
+++ b/Configurability/ConfigurableServiceHelper.php
@@ -96,11 +96,13 @@ class ConfigurableServiceHelper
         return $context;
     }
 
-    public function resolveArray($input, &$context){
+    public function resolveArray($input, &$context)
+    {
         $output = [];
-        foreach($input as $key => $value){
-            $output[$key] = $this->resolve($value,$context);
+        foreach ($input as $key => $value) {
+            $output[$key] = $this->resolve($value, $context);
         }
+
         return $output;
     }
 
@@ -163,6 +165,7 @@ class ConfigurableServiceHelper
                 break;
             case self::STEP_VALIDATE:
                 $this->validate($stepActionParams, $context);
+
                 return true;
                 break;
             default:
@@ -196,7 +199,6 @@ class ConfigurableServiceHelper
 
     public function validate(array $stepConfig, array &$context)
     {
-
         $config = $this->validateResolver->resolve($stepConfig);
 
         $rule = $config[self::CONF_RULE];
@@ -206,7 +208,7 @@ class ConfigurableServiceHelper
         $display_message = $config[self::CONF_DISPLAY_MESSAGE];
 
         $evaluation = $this->resolve($rule, $context);
-        if ($evaluation !== true) {
+        if (true !== $evaluation) {
             $message = $this->resolve($message, $context);
             if ($no_results) {
                 throw new NoResultsException($message);

--- a/Configurability/ConfigurableServiceHelper.php
+++ b/Configurability/ConfigurableServiceHelper.php
@@ -31,9 +31,11 @@ class ConfigurableServiceHelper
     const CONF_RECOVERABLE = 'recoverable';
 
     const CONF_NO_RESULTS = 'noResults';
-    const STEP_DEFINE = 'define';
 
+    const STEP_DEFINE = 'define';
     const STEP_VALIDATE = 'validate';
+    const STEP_DEBUG = 'debug';
+
     const OPTION_METHOD = 'method';
     const KEY_DESCRIPTION = 'description';
     const KEY_RESPONSE = 'response';
@@ -168,6 +170,10 @@ class ConfigurableServiceHelper
 
                 return true;
                 break;
+            case self::STEP_DEBUG:
+                $this->debug($stepActionParams, $context);
+
+                return true;
             default:
                 return false;
                 break;
@@ -224,6 +230,49 @@ class ConfigurableServiceHelper
                 throw $exception;
             }
         }
+    }
+
+    /**
+     * Nasty hack to be able to easily display context variables in producers.
+     *
+     * @param array $actions
+     * @param $context
+     */
+    protected function debug($actions, &$context)
+    {
+        if (!is_array($actions)) {
+            return;
+        }
+        foreach ($actions as $action => $parameters) {
+            if ('display' == $action) {
+                foreach ($parameters as $var) {
+                    echo "\n";
+                    echo $var.' => ';
+                    $command = 'print_r($'.$var.');';
+                    eval($command);
+                }
+                flush();
+                ob_flush();
+            }
+
+            if ('break' == $action && false !== $parameters) {
+                if (function_exists('xdebug_break')) {
+                    xdebug_break();
+                }
+            }
+
+            if ('sleep' == $action) {
+                echo 'Sleeping for '.$parameters.' seconds due to sleep step...'."\n";
+                sleep($parameters);
+            }
+
+            if ('exit' == $action && false !== $parameters) {
+                echo 'Exit due to debug step'."\n";
+                exit;
+            }
+        }
+
+        return;
     }
 
     public function runValidations(array $validations, array &$context)

--- a/Configurability/ConfigurableServiceHelper.php
+++ b/Configurability/ConfigurableServiceHelper.php
@@ -31,11 +31,9 @@ class ConfigurableServiceHelper
     const CONF_RECOVERABLE = 'recoverable';
 
     const CONF_NO_RESULTS = 'noResults';
-
     const STEP_DEFINE = 'define';
-    const STEP_VALIDATE = 'validate';
-    const STEP_DEBUG = 'debug';
 
+    const STEP_VALIDATE = 'validate';
     const OPTION_METHOD = 'method';
     const KEY_DESCRIPTION = 'description';
     const KEY_RESPONSE = 'response';
@@ -98,13 +96,11 @@ class ConfigurableServiceHelper
         return $context;
     }
 
-    public function resolveArray($input, &$context)
-    {
+    public function resolveArray($input, &$context){
         $output = [];
-        foreach ($input as $key => $value) {
-            $output[$key] = $this->resolve($value, $context);
+        foreach($input as $key => $value){
+            $output[$key] = $this->resolve($value,$context);
         }
-
         return $output;
     }
 
@@ -167,13 +163,8 @@ class ConfigurableServiceHelper
                 break;
             case self::STEP_VALIDATE:
                 $this->validate($stepActionParams, $context);
-
                 return true;
                 break;
-            case self::STEP_DEBUG:
-                $this->debug($stepActionParams, $context);
-
-                return true;
             default:
                 return false;
                 break;
@@ -205,6 +196,7 @@ class ConfigurableServiceHelper
 
     public function validate(array $stepConfig, array &$context)
     {
+
         $config = $this->validateResolver->resolve($stepConfig);
 
         $rule = $config[self::CONF_RULE];
@@ -214,7 +206,7 @@ class ConfigurableServiceHelper
         $display_message = $config[self::CONF_DISPLAY_MESSAGE];
 
         $evaluation = $this->resolve($rule, $context);
-        if (true !== $evaluation) {
+        if ($evaluation !== true) {
             $message = $this->resolve($message, $context);
             if ($no_results) {
                 throw new NoResultsException($message);
@@ -230,49 +222,6 @@ class ConfigurableServiceHelper
                 throw $exception;
             }
         }
-    }
-
-    /**
-     * Nasty hack to be able to easily display context variables in producers.
-     *
-     * @param array $actions
-     * @param $context
-     */
-    protected function debug($actions, &$context)
-    {
-        if (!is_array($actions)) {
-            return;
-        }
-        foreach ($actions as $action => $parameters) {
-            if ('display' == $action) {
-                foreach ($parameters as $var) {
-                    echo "\n";
-                    echo $var.' => ';
-                    $command = 'print_r($'.$var.');';
-                    eval($command);
-                }
-                flush();
-                ob_flush();
-            }
-
-            if ('break' == $action && false !== $parameters) {
-                if (function_exists('xdebug_break')) {
-                    xdebug_break();
-                }
-            }
-
-            if ('sleep' == $action) {
-                echo 'Sleeping for '.$parameters.' seconds due to sleep step...'."\n";
-                sleep($parameters);
-            }
-
-            if ('exit' == $action && false !== $parameters) {
-                echo 'Exit due to debug step'."\n";
-                exit;
-            }
-        }
-
-        return;
     }
 
     public function runValidations(array $validations, array &$context)

--- a/Tests/Unit/Components/WebService/Rest/RestConfigurableProducerTest.php
+++ b/Tests/Unit/Components/WebService/Rest/RestConfigurableProducerTest.php
@@ -86,6 +86,7 @@ class RestConfigurableProducerTest extends \PHPUnit_Framework_TestCase
             RestConfigurableProducer::REQUEST_HTTP_VERB => 'POST',
             RestConfigurableProducer::REQUEST_BODY => ['hello' => 'world'],
             RestConfigurableProducer::REQUEST_URI => 'something',
+            RestConfigurableProducer::RESPONSE_DISPLAY_ERROR => false,
         ];
 
         $options = [

--- a/Tests/Unit/Components/WebService/Rest/RestConfigurableProducerTest.php
+++ b/Tests/Unit/Components/WebService/Rest/RestConfigurableProducerTest.php
@@ -86,7 +86,7 @@ class RestConfigurableProducerTest extends \PHPUnit_Framework_TestCase
             RestConfigurableProducer::REQUEST_HTTP_VERB => 'POST',
             RestConfigurableProducer::REQUEST_BODY => ['hello' => 'world'],
             RestConfigurableProducer::REQUEST_URI => 'something',
-            RestConfigurableProducer::RESPONSE_DISPLAY_ERROR => false,
+            RestConfigurableProducer::DISPLAY_RESPONSE_ERROR => false,
         ];
 
         $options = [


### PR DESCRIPTION
Using a producer config parameter on request (display_error), the SOAP and REST APIs should return the message and code from the original exception.