### PR TITLE
MINT-2489 Adding new stripSentence to ExpressionLanguageProvider

### DIFF
--- a/Tests/Functional/Tools/Evaluator/ExpressionEvaluatorTest.php
+++ b/Tests/Functional/Tools/Evaluator/ExpressionEvaluatorTest.php
@@ -151,29 +151,29 @@ class ExpressionEvaluatorTest extends KernelTestCase
                 'expression' => 'strtoupper("SUPER AWESOME")',
                 'vars' => [],
             ],
-            'Check stripSentence returns only the first matched words when the next one is not full and separated by space' => [
+            'Check splitSentence returns only the first matched words when the next one is not full and separated by space' => [
                 'expected' => 'Perico de los Palotes Moreno',
-                'expression' => 'stripSentence("Perico de los Palotes Moreno Martinez", 0, 30)',
+                'expression' => 'splitSentence("Perico de los Palotes Moreno Martinez", 0, 30)',
                 'vars' => [],
             ],
-            'Check stripSentence returns only the first match words when the full length does not match the whole next word' => [
+            'Check splitSentence returns only the first match words when the full length does not match the whole next word' => [
                 'expected' => 'Test',
-                'expression' => 'stripSentence("Test Superhipermegalonglastname", 0, 30)',
+                'expression' => 'splitSentence("Test Superhipermegalonglastname", 0, 30)',
                 'vars' => [],
             ],
-            'Check stripSentence return all the strings starting from the last match word based on start/length ' => [
+            'Check splitSentence return all the strings starting from the last match word based on start/length ' => [
                 'expected' => 'Superhipermegalonglastname',
-                'expression' => 'stripSentence("Test Superhipermegalonglastname", 30, 60)',
+                'expression' => 'splitSentence("Test Superhipermegalonglastname", 30, 60)',
                 'vars' => [],
             ],
-            'Check stripSentence retrieve the full name when its strlength is less than the requested' => [
+            'Check splitSentence retrieve the full name when its strlength is less than the requested' => [
                 'expected' => 'Maria Leon',
-                'expression' => 'stripSentence("Maria Leon", 0, 30)',
+                'expression' => 'splitSentence("Maria Leon", 0, 30)',
                 'vars' => [],
             ],
-            'Check stripSentence returns empty when the start/length does not match' => [
+            'Check splitSentence returns empty when the start/length does not match' => [
                 'expected' => '',
-                'expression' => 'stripSentence("Maria Leon", 30, 60)',
+                'expression' => 'splitSentence("Maria Leon", 30, 60)',
                 'vars' => [],
             ],
         ];

--- a/Tests/Functional/Tools/Evaluator/ExpressionEvaluatorTest.php
+++ b/Tests/Functional/Tools/Evaluator/ExpressionEvaluatorTest.php
@@ -151,6 +151,31 @@ class ExpressionEvaluatorTest extends KernelTestCase
                 'expression' => 'strtoupper("SUPER AWESOME")',
                 'vars' => [],
             ],
+            'Check stripSentence returns only the first matched words when the next one is not full and separated by space' => [
+                'expected' => 'Perico de los Palotes Moreno',
+                'expression' => 'stripSentence("Perico de los Palotes Moreno Martinez", 0, 30)',
+                'vars' => [],
+            ],
+            'Check stripSentence returns only the first match words when the full length does not match the whole next word' => [
+                'expected' => 'Test',
+                'expression' => 'stripSentence("Test Superhipermegalonglastname", 0, 30)',
+                'vars' => [],
+            ],
+            'Check stripSentence return all the strings starting from the last match word based on start/length ' => [
+                'expected' => 'Superhipermegalonglastname',
+                'expression' => 'stripSentence("Test Superhipermegalonglastname", 30, 60)',
+                'vars' => [],
+            ],
+            'Check stripSentence retrieve the full name when its strlength is less than the requested' => [
+                'expected' => 'Maria Leon',
+                'expression' => 'stripSentence("Maria Leon", 0, 30)',
+                'vars' => [],
+            ],
+            'Check stripSentence returns empty when the start/length does not match' => [
+                'expected' => '',
+                'expression' => 'stripSentence("Maria Leon", 30, 60)',
+                'vars' => [],
+            ],
         ];
     }
 

--- a/Tools/Evaluator/CustomExpressionLanguageProvider.php
+++ b/Tools/Evaluator/CustomExpressionLanguageProvider.php
@@ -26,6 +26,7 @@ class CustomExpressionLanguageProvider implements ExpressionFunctionProviderInte
             $this->createImplodeFunction(),
             $this->createRemoveNewLinesFunction(),
             $this->createStrtoupperFunction(),
+            $this->createSplitSentenceFunction()
         ];
     }
 
@@ -311,6 +312,37 @@ class CustomExpressionLanguageProvider implements ExpressionFunctionProviderInte
             },
             function ($arguments, $string) {
                 return strtoupper($string);
+            }
+        );
+    }
+
+    /**
+     * Returns the uppercased string.
+     *
+     * @return ExpressionFunction
+     */
+    protected function createSplitSentenceFunction()
+    {
+        return new ExpressionFunction(
+            'splitSentence',
+            function ($string, $start, $length) {
+                return sprintf('splitSentence(%s, %s, %s)', $string, $start, $length);
+            },
+            function ($arguments, $string, $start, $length) {
+
+                $currentStringToArray = explode(" ", substr($string, $start, $length));
+                $stringToArray = explode(" ", $string);
+
+                $splitted = \array_intersect($currentStringToArray, $stringToArray);
+
+                if(!\count($splitted) && !empty($currentString)) {
+                    $originalItem = end($stringToArray);
+                    if(false !== \strpos($originalItem, $currentStringToArray[0])) {
+                        $splitted[] = $originalItem;
+                    }
+                }
+
+                return trim(implode(' ', $splitted));
             }
         );
     }

--- a/Tools/Evaluator/CustomExpressionLanguageProvider.php
+++ b/Tools/Evaluator/CustomExpressionLanguageProvider.php
@@ -330,7 +330,8 @@ class CustomExpressionLanguageProvider implements ExpressionFunctionProviderInte
             },
             function ($arguments, $string, $start, $length) {
 
-                $currentStringToArray = explode(" ", substr($string, $start, $length));
+                $currentString = substr($string, $start, $length);
+                $currentStringToArray = explode(" ", $currentString);
                 $stringToArray = explode(" ", $string);
 
                 $splitted = \array_intersect($currentStringToArray, $stringToArray);


### PR DESCRIPTION
A new function was added to the evaluator.
Feature:

- its possible now to  do a "substr" using words separated by whitspaces, considering the length of the last word. Ex.:

```
$string = "Perico de los Palotes Moreno Martinez";
splitSentence($string 0, 30); //return Perico de los Palotes Moreno
splitSentence($string, 30, 60); //return Martinez
```

```
$string = "Test Superhipermegalonglastname";
splitSentence($string 0, 30); //return Test
splitSentence($string, 30, 60); //return Superhipermegalonglastname
```

```
$string = "Maria Leon";
splitSentence($string 0, 30); //return Maria Leon
splitSentence($string, 30, 60); //return ''
```