### PR TITLE
Remove unneeded trait use;

### DIFF
--- a/Core/Processors/Processor.php
+++ b/Core/Processors/Processor.php
@@ -21,7 +21,6 @@ abstract class Processor extends Service implements ProcessorInterface
     const CONTEXT_PROCESSOR_DESCRIPTION = 'processor_description';
 
     use UsesValidator;
-    use UsesEventDispatcher;
 
     /**
      * @var string


### PR DESCRIPTION
Already included by  `Smartbox\Integration\FrameworkBundle\Service`