### PR TITLE
Option stop_on_no_results can also be passed as integer

### DIFF
--- a/Components/DB/Dbal/ConfigurableDbalProtocol.php
+++ b/Components/DB/Dbal/ConfigurableDbalProtocol.php
@@ -48,7 +48,7 @@ class ConfigurableDbalProtocol extends Protocol implements DescriptableInterface
         ]);
 
         $resolver->setAllowedTypes(self::OPTION_METHOD, ['string']);
-        $resolver->setAllowedTypes(self::OPTION_STOP_ON_NO_RESULTS, ['bool']);
+        $resolver->setAllowedTypes(self::OPTION_STOP_ON_NO_RESULTS, ['bool', 'numeric']);
         $resolver->setAllowedTypes(self::OPTION_DB_CONNECTION_NAME, 'string');
         $resolver->setAllowedTypes(self::OPTION_SLEEP_TIME, 'numeric');
         $resolver->setAllowedTypes(self::OPTION_INACTIVITY_TRIGGER, 'numeric');


### PR DESCRIPTION
If we want to pass a boolean value from the command line, then it has to be an integer (0 or 1). So OPTION_STOP_ON_NO_RESULTS needs to be either bool or numeric to be valid.