### PR TITLE
Bugfix/request headers temp fix

### DIFF
--- a/Components/WebService/Soap/Exceptions/SoapException.php
+++ b/Components/WebService/Soap/Exceptions/SoapException.php
@@ -3,6 +3,7 @@
 namespace Smartbox\Integration\FrameworkBundle\Components\WebService\Soap\Exceptions;
 
 use JMS\Serializer\Annotation as JMS;
+use JMS\Serializer\Annotation\Accessor;
 use Smartbox\CoreBundle\Type\SerializableInterface;
 use Smartbox\CoreBundle\Type\Traits\HasInternalType;
 use Smartbox\Integration\FrameworkBundle\Components\WebService\Exception\ExternalSystemExceptionInterface;
@@ -25,6 +26,7 @@ class SoapException extends \Exception implements SerializableInterface, Externa
      * @JMS\Expose
      * @JMS\Type("array")
      * @JMS\SerializedName("requestHeaders")
+     * @Accessor(getter="getResponseHeaders",setter="setsRequestHeadersTypeUnknown")
      * @JMS\Groups({"logs"})
      */
     protected $requestHeaders;
@@ -159,6 +161,23 @@ class SoapException extends \Exception implements SerializableInterface, Externa
 
         return $this;
     }
+
+    /**
+     *
+     * @return SoapException
+     */
+    public function setsRequestHeadersTypeUnknown($responseHeaders)
+    {
+        if(is_string($responseHeaders)){
+            $this->responseHeaders = array($responseHeaders);
+        }elseif(is_array($responseHeaders)){
+            $this->responseHeaders = $responseHeaders;
+        }else{
+            $this->responseHeaders = array();
+        }
+        return $this;
+    }
+
 
     /**
      * @return string

--- a/Components/WebService/Soap/Exceptions/SoapException.php
+++ b/Components/WebService/Soap/Exceptions/SoapException.php
@@ -166,14 +166,14 @@ class SoapException extends \Exception implements SerializableInterface, Externa
      *
      * @return SoapException
      */
-    public function setsRequestHeadersTypeUnknown($responseHeaders)
+    public function setsRequestHeadersTypeUnknown($requestHeaders)
     {
-        if(is_string($responseHeaders)){
-            $this->responseHeaders = array($responseHeaders);
-        }elseif(is_array($responseHeaders)){
-            $this->responseHeaders = $responseHeaders;
+        if(is_string($requestHeaders)){
+            $this->requestHeaders = array($requestHeaders);
+        }elseif(is_array($requestHeaders)){
+            $this->requestHeaders = $requestHeaders;
         }else{
-            $this->responseHeaders = array();
+            $this->requestHeaders = array();
         }
         return $this;
     }

--- a/Components/WebService/Soap/Exceptions/SoapException.php
+++ b/Components/WebService/Soap/Exceptions/SoapException.php
@@ -24,9 +24,8 @@ class SoapException extends \Exception implements SerializableInterface, Externa
     /**
      * @var array
      * @JMS\Expose
-     * @JMS\Type("array")
+     * @JMS\Type("starray")
      * @JMS\SerializedName("requestHeaders")
-     * @Accessor(getter="getResponseHeaders",setter="setsRequestHeadersTypeUnknown")
      * @JMS\Groups({"logs"})
      */
     protected $requestHeaders;
@@ -43,7 +42,7 @@ class SoapException extends \Exception implements SerializableInterface, Externa
     /**
      * @var array
      * @JMS\Expose
-     * @JMS\Type("array")
+     * @JMS\Type("starray")
      * @JMS\SerializedName("responseHeaders")
      * @JMS\Groups({"logs"})
      */
@@ -161,23 +160,6 @@ class SoapException extends \Exception implements SerializableInterface, Externa
 
         return $this;
     }
-
-    /**
-     *
-     * @return SoapException
-     */
-    public function setsRequestHeadersTypeUnknown($requestHeaders)
-    {
-        if(is_string($requestHeaders)){
-            $this->requestHeaders = array($requestHeaders);
-        }elseif(is_array($requestHeaders)){
-            $this->requestHeaders = $requestHeaders;
-        }else{
-            $this->requestHeaders = array();
-        }
-        return $this;
-    }
-
 
     /**
      * @return string

--- a/Events/StarrayHandler.php
+++ b/Events/StarrayHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Smartbox\Integration\FrameworkBundle\Events;
+
+use JMS\Serializer\Context;
+use JMS\Serializer\GraphNavigator;
+use JMS\Serializer\Handler\SubscribingHandlerInterface;
+use JMS\Serializer\VisitorInterface;
+
+class StarrayHandler implements SubscribingHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribingMethods()
+    {
+        return array(
+            array(
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format' => 'json',
+                'type' => 'starray',
+                'method' => 'serializeStringOrArrayToArray',
+            ),
+        );
+    }
+
+    /**
+     * The de-serialization function, which will return always an array.
+     * This is a temporary solution to a problem.
+     *
+     * @param VisitorInterface $visitor
+     * @param string|array     $data
+     * @param array            $type
+     *
+     * @return array
+     */
+    public function serializeStringOrArrayToArray(VisitorInterface $visitor, $data, array $type, Context $context)
+    {
+        if (is_string($data)) {
+            return array($data);
+        } elseif (is_array($data)) {
+            return $data;
+        } else {
+            return array();
+        }
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -24,6 +24,7 @@ parameters:
   smartesb.steps_provider.dbal.class: Smartbox\Integration\FrameworkBundle\Components\DB\Dbal\DbalStepsProvider
   smartesb.steps_provider.nosql.class: Smartbox\Integration\FrameworkBundle\Components\DB\NoSQL\NoSQLStepsProvider
   smartesb.steps_provider.csv.class: Smartbox\Integration\FrameworkBundle\Components\FileService\Csv\CsvConfigurableStepsProvider
+  smartesb.serialization.handler.starray.class: Smartbox\Integration\FrameworkBundle\Events\StarrayHandler
 
 services:
   smartesb.serialization.handler.mongodate:
@@ -108,3 +109,8 @@ services:
 
   smartesb.handlers.async:
       class: '%smartesb.handlers.message_routing.class%'
+
+  smartesb.serialization.handler.starray:
+      class: '%smartesb.serialization.handler.starray.class%'
+      tags:
+          - { name: jms_serializer.subscribing_handler }


### PR DESCRIPTION
Adding a temporary fix to deal with serialization of older versions of events that had requestHeaders as a string. 