### PR TITLE
Feature/map all dissociative array and expression language getKey/Value methods

### DIFF
--- a/Tests/Functional/Tools/Evaluator/ExpressionEvaluatorTest.php
+++ b/Tests/Functional/Tools/Evaluator/ExpressionEvaluatorTest.php
@@ -211,16 +211,18 @@ class ExpressionEvaluatorTest extends KernelTestCase
      * @dataProvider dataProviderForFailedExpressionsEvaluatedWithVars
      *
      * @param $exception
-     * @param $exception
+     * @param $message
      * @param $expression
      * @param array $vars
+     *
+     * @throws \Exception
      */
     public function testFailedEvaluateWithVars($exception, $message, $expression, array $vars)
     {
-        $this->evaluator->evaluateWithVars($expression, $vars);
-
         $this->expectException($exception);
         $this->expectExceptionMessage($message);
+
+        $this->evaluator->evaluateWithVars($expression, $vars);
     }
 
     /**

--- a/Tests/Functional/Tools/Evaluator/ExpressionEvaluatorTest.php
+++ b/Tests/Functional/Tools/Evaluator/ExpressionEvaluatorTest.php
@@ -151,6 +151,34 @@ class ExpressionEvaluatorTest extends KernelTestCase
                 'expression' => 'strtoupper("SUPER AWESOME")',
                 'vars' => [],
             ],
+            'Checking getKey expression for not existing KEY index' => [
+                'expected' => false,
+                'expression' => 'getKey(array)',
+                'vars' => [
+                    'array' => ['VALUE_WITH_NO_KEY'],
+                ],
+            ],
+            'Checking getKey expression for existing KEY index' => [
+                'expected' => 'VALUE_WITH_KEY',
+                'expression' => 'getKey(array)',
+                'vars' => [
+                    'array' => ['key' => 'VALUE_WITH_KEY'],
+                ],
+            ],
+            'Checking getValue expression for existing VALUE index' => [
+                'expected' => 'VALUE_WITH_VALUE_KEY',
+                'expression' => 'getValue(array)',
+                'vars' => [
+                    'array' => ['value' => 'VALUE_WITH_VALUE_KEY'],
+                ],
+            ],
+            'Checking getValue expression for existing VALUE index' => [
+                'expected' => false,
+                'expression' => 'getValue(array)',
+                'vars' => [
+                    'array' => ['VALUE_WITH_NO_VALUE_KEY'],
+                ],
+            ],
         ];
     }
 
@@ -161,6 +189,8 @@ class ExpressionEvaluatorTest extends KernelTestCase
      * @param $expected
      * @param $expression
      * @param array $vars
+     *
+     * @throws \Exception
      */
     public function testEvaluateWithVars($expected, $expression, array $vars)
     {

--- a/Tests/Functional/Tools/Evaluator/ExpressionEvaluatorTest.php
+++ b/Tests/Functional/Tools/Evaluator/ExpressionEvaluatorTest.php
@@ -151,13 +151,6 @@ class ExpressionEvaluatorTest extends KernelTestCase
                 'expression' => 'strtoupper("SUPER AWESOME")',
                 'vars' => [],
             ],
-            'Checking getKey expression for not existing KEY index' => [
-                'expected' => false,
-                'expression' => 'getKey(array)',
-                'vars' => [
-                    'array' => ['VALUE_WITH_NO_KEY'],
-                ],
-            ],
             'Checking getKey expression for existing KEY index' => [
                 'expected' => 'VALUE_WITH_KEY',
                 'expression' => 'getKey(array)',
@@ -172,8 +165,26 @@ class ExpressionEvaluatorTest extends KernelTestCase
                     'array' => ['value' => 'VALUE_WITH_VALUE_KEY'],
                 ],
             ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForFailedExpressionsEvaluatedWithVars()
+    {
+        return [
+            'Checking getKey expression for not existing KEY index' => [
+                'exception' => \RuntimeException::class,
+                'message' => 'The argument passed to "getKey" should have a index called "key"',
+                'expression' => 'getKey(array)',
+                'vars' => [
+                    'array' => ['VALUE_WITH_NO_KEY'],
+                ],
+            ],
             'Checking getValue expression for existing VALUE index' => [
-                'expected' => false,
+                'exception' => \RuntimeException::class,
+                'message' => 'The argument passed to "getValue" should have a index called "value"',
                 'expression' => 'getValue(array)',
                 'vars' => [
                     'array' => ['VALUE_WITH_NO_VALUE_KEY'],
@@ -189,12 +200,27 @@ class ExpressionEvaluatorTest extends KernelTestCase
      * @param $expected
      * @param $expression
      * @param array $vars
-     *
-     * @throws \Exception
      */
     public function testEvaluateWithVars($expected, $expression, array $vars)
     {
         $this->assertEquals($expected, $this->evaluator->evaluateWithVars($expression, $vars));
+    }
+
+    /**
+     * @covers ::failedEvaluateWithVars
+     * @dataProvider dataProviderForFailedExpressionsEvaluatedWithVars
+     *
+     * @param $exception
+     * @param $exception
+     * @param $expression
+     * @param array $vars
+     */
+    public function testFailedEvaluateWithVars($exception, $message, $expression, array $vars)
+    {
+        $this->evaluator->evaluateWithVars($expression, $vars);
+
+        $this->expectException($exception);
+        $this->expectExceptionMessage($message);
     }
 
     /**

--- a/Tools/Evaluator/CustomExpressionLanguageProvider.php
+++ b/Tools/Evaluator/CustomExpressionLanguageProvider.php
@@ -358,11 +358,11 @@ class CustomExpressionLanguageProvider implements ExpressionFunctionProviderInte
             },
             function ($arguments, $array) {
                 if (!is_array($array)) {
-                    throw new \RuntimeException('Argument passed to "getKey" should be an array.');
+                    throw new \RuntimeException('Argument passed to "getValue" should be an array.');
                 }
 
                 if (!isset($array['value'])) {
-                    throw new \RuntimeException('The argument passed to "getKey" should have a index called "value"');
+                    throw new \RuntimeException('The argument passed to "getValue" should have a index called "value"');
                 }
 
                 return $array['value'];

--- a/Tools/Evaluator/CustomExpressionLanguageProvider.php
+++ b/Tools/Evaluator/CustomExpressionLanguageProvider.php
@@ -26,6 +26,8 @@ class CustomExpressionLanguageProvider implements ExpressionFunctionProviderInte
             $this->createImplodeFunction(),
             $this->createRemoveNewLinesFunction(),
             $this->createStrtoupperFunction(),
+            $this->createGetKeyFunction(),
+            $this->createGetValueFunction(),
         ];
     }
 
@@ -311,6 +313,59 @@ class CustomExpressionLanguageProvider implements ExpressionFunctionProviderInte
             },
             function ($arguments, $string) {
                 return strtoupper($string);
+            }
+        );
+    }
+
+    /**
+     * Returns the keys from an array.
+     *
+     * @return ExpressionFunction
+     */
+    protected function createGetKeyFunction()
+    {
+        return new ExpressionFunction(
+            'getKey',
+            function ($array) {
+                return sprintf('getKey(%s)', $array);
+            },
+            function ($arguments, $array) {
+                if (!is_array($array)) {
+                    throw new \RuntimeException('Argument passed to "getKey" should be an array.');
+                }
+
+                if (!isset($array['key'])) {
+                    throw new \RuntimeException('The argument passed to "getKey" should have a index called "key"');
+                }
+
+                return $array['key'];
+            }
+        );
+    }
+
+    /**
+     * Returns the key value from a disassociate array.
+     * $array should be as ['key' => 123, 'value' => 222].
+     *
+     * @return ExpressionFunction
+     */
+    protected function createGetValueFunction()
+    {
+        return new ExpressionFunction(
+            'getValue',
+            function ($array) {
+                return sprintf('getValue(%s)', $array);
+            },
+            function ($arguments, $array) {
+                if (!is_array($array)) {
+                    throw new \RuntimeException('Argument passed to "getKey" should be an array.');
+                }
+
+                if (!isset($array['value'])) {
+                    throw new \RuntimeException('The argument passed to "getKey" should have a index called "value"');
+                }
+
+                return $array['value'];
             }
         );
     }

--- a/Tools/Mapper/Mapper.php
+++ b/Tools/Mapper/Mapper.php
@@ -94,7 +94,9 @@ class Mapper implements MapperInterface
      * @param $obj
      * @param $context
      *
-     * @return array|null|string
+     * @return array|string|null
+     *
+     * @throws \Exception
      */
     public function resolve(&$mapping, &$obj, &$context)
     {
@@ -130,13 +132,14 @@ class Mapper implements MapperInterface
     }
 
     /**
-     * @param mixed  $elements
+     * @param array  $elements
      * @param string $mappingName
-     * @param mixed  $context
+     * @param array  $context
+     * @param bool   $disassociate
      *
-     * @return array
+     * @return array|mixed
      */
-    public function mapAll($elements, $mappingName, $context = [])
+    public function mapAll($elements, $mappingName, $context = [], $disassociate = false)
     {
         if (!is_array($elements)) {
             throw new \RuntimeException('MapAll expected an array');
@@ -148,6 +151,7 @@ class Mapper implements MapperInterface
 
         $res = [];
         foreach ($elements as $key => $element) {
+            $element = ($disassociate) ? ['key' => $key, 'value' => $element] : $element;
             $res[$key] = $this->map($element, $mappingName, $context);
         }
 


### PR DESCRIPTION
Added a flag on Mapper.mapAll to create an dissociate array when key/value are needed:

Response from external system:
```
"my_data": {
    "KEY_1": "VALUE_1"
}
```

Mapping using the new flag:

`myData: "mapper.mapAll(obj['my_data'], 'map_key_value', [], **true**)" `

For this cases we need to map the key AND the value as properties on the new Object
```
map_key_value: 
          key: getKey(obj) //KEY_1
          value: getValue(obj) //VALUE_1
```