### PR TITLE
Add an option to allow empty values

### DIFF
--- a/Tests/Unit/Tools/Mapper/MapperTest.php
+++ b/Tests/Unit/Tools/Mapper/MapperTest.php
@@ -240,7 +240,6 @@ class MapperTest extends \PHPUnit\Framework\TestCase
      * @param array $context
      *
      * @dataProvider provideEmptyValues
-     * @group zboob
      */
     public function testShouldAcceptEmptyValues($expected, $obj, $context = [])
     {

--- a/Tools/Mapper/Mapper.php
+++ b/Tools/Mapper/Mapper.php
@@ -80,7 +80,7 @@ class Mapper implements MapperInterface
             throw new \InvalidArgumentException(sprintf('Invalid mapping name "%s"', $mappingName));
         }
 
-        if (empty($obj) || $this->shouldAcceptEmptyValues($context, $obj)) {
+        if (empty($obj) && !$this->shouldAcceptEmptyValues($context, $obj)) {
             return $obj;
         }
 

--- a/Tools/Mapper/Mapper.php
+++ b/Tools/Mapper/Mapper.php
@@ -80,7 +80,7 @@ class Mapper implements MapperInterface
             throw new \InvalidArgumentException(sprintf('Invalid mapping name "%s"', $mappingName));
         }
 
-        if (empty($obj) && !$this->shouldAcceptEmptyValues($context, $obj)) {
+        if (empty($obj) || $this->shouldAcceptEmptyValues($context, $obj)) {
             return $obj;
         }
 
@@ -414,7 +414,7 @@ class Mapper implements MapperInterface
     }
 
     /**
-     * Will check if a value match a specific type, adn if so will still map it. Ex:
+     * Will check if a value match a specific type, and if so will still map it. Ex:
      * - `allow_empty_string => true` will allow ''
      * - `allow_empty_numeric => true` will allow 0
      *

--- a/Tools/Mapper/Mapper.php
+++ b/Tools/Mapper/Mapper.php
@@ -80,7 +80,7 @@ class Mapper implements MapperInterface
             throw new \InvalidArgumentException(sprintf('Invalid mapping name "%s"', $mappingName));
         }
 
-        if (empty($obj)) {
+        if (empty($obj) && !$this->shouldAcceptEmptyValues($context, $obj)) {
             return $obj;
         }
 
@@ -411,5 +411,27 @@ class Mapper implements MapperInterface
         } else {
             return $value;
         }
+    }
+
+    /**
+     * Will check if a value match a specific type, adn if so will still map it. Ex:
+     * - `allow_empty_string => true` will allow ''
+     * - `allow_empty_numeric => true` will allow 0
+     *
+     *
+     * @param array $context
+     * @param mixed $obj
+     *
+     * @return bool
+     */
+    protected function shouldAcceptEmptyValues(array $context, $obj): bool
+    {
+        foreach ($context as $key => $val) {
+            if (preg_match('/^allow_empty_(\w+)$/', $key, $matches) && $val) {
+                return (bool) call_user_func("is_{$matches[1]}", $obj);
+            }
+        }
+
+        return false;
     }
 }

--- a/Tools/Mapper/Mapper.php
+++ b/Tools/Mapper/Mapper.php
@@ -418,7 +418,6 @@ class Mapper implements MapperInterface
      * - `allow_empty_string => true` will allow ''
      * - `allow_empty_numeric => true` will allow 0
      *
-     *
      * @param array $context
      * @param mixed $obj
      *


### PR DESCRIPTION
Specify in the context of the `map` or `mapAll` function if you want to allow empty values of a specific type:
```yaml
my_mapping:
            foo: mapper.mapAll(obj['bar'], 'something', ['allow_empty_string' => true]) # Will allow '' as a value
```