### PR TITLE
Add labels as constants to smoke tests

### DIFF
--- a/Tools/SmokeTests/CanCheckConnectivityInterface.php
+++ b/Tools/SmokeTests/CanCheckConnectivityInterface.php
@@ -10,6 +10,14 @@ use Smartbox\CoreBundle\Utils\SmokeTest\Output\SmokeTestOutputInterface;
 interface CanCheckConnectivityInterface
 {
     /**
+     * The label defines the critical level for smoke tests.
+     * By default smoke-tests skips the WIP label
+     */
+    const SMOKE_TEST_LABEL_EMPTY = '';
+    const SMOKE_TEST_LABEL_WIP = 'WIP';
+    const SMOKE_TEST_LABEL_IMPORTANT = 'important';
+    const SMOKE_TEST_LABEL_CRITICAL = 'critical';
+    /**
      * @param array $config
      *
      * @return SmokeTestOutputInterface

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "ext-pcntl": "*",
         "guzzlehttp/guzzle": "^6.0",
         "smartbox/besimple-soap": "^1.3",
-        "smartbox/core-bundle": "~1.6",
+        "smartbox/core-bundle": "dev-smoke-tests-labels",
         "symfony/expression-language": "^2.8 || ^3.4",
         "symfony/framework-bundle": "^2.8.18 || ^3.4",
         "symfony/options-resolver": "^2.8 || ^3.4",


### PR DESCRIPTION
This feature is used on the smoke tests and can bring facilities like skip tests by label by default