### PR TITLE
SF34: Fix incorrect path to cache folder

### DIFF
--- a/Resources/config/smoke_tests.yml
+++ b/Resources/config/smoke_tests.yml
@@ -14,7 +14,7 @@ services:
 
   smartesb.smoke_test.file_permissions:
       class: "%smartesb.smoke_test.file_permissions.class%"
-      arguments: [ '%kernel.root_dir%/cache' ]
+      arguments: [ "@=service('kernel').getCacheDir()" ] # TODO: Once 2.8 support is dropped, replace this with '%kernel.cache_dir%'
       tags:
           - { name: smartcore.smoke_test, labels: "important" }
 


### PR DESCRIPTION
This fixes the incorrect assumption that the cache folder is in app/cache.

Smoke tests previously figured the path by getting the kernel root dir and adding cache in front of it. This change will get the cache folder path directly from the kernel.