### PR TITLE
Prevent 500 errors on invalid mappings/payloads

### DIFF
--- a/Tools/Evaluator/EvaluatorException.php
+++ b/Tools/Evaluator/EvaluatorException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Smartbox\Integration\FrameworkBundle\Tools\Evaluator;
+
+
+class EvaluatorException extends \RuntimeException
+{
+
+}

--- a/Tools/Evaluator/ExpressionEvaluator.php
+++ b/Tools/Evaluator/ExpressionEvaluator.php
@@ -51,12 +51,13 @@ class ExpressionEvaluator
             'serializer' => $this->getSerializer(),
             'mapper' => $this->getMapper(),
         ]);
+
         try {
             $evaluated = $this->language->evaluate($expression, $vars);
         } catch (\Exception $e) {
-            $class = get_class($e);
-            throw new $class("Could not evaluate '{$expression}'. " . $e->getMessage(), $e->getCode(), $e );
+            throw new EvaluatorException(sprintf('Could not evaluate "%s": %s', $expression, $e->getMessage()), $e->getCode(), $e);
         }
+
         return $evaluated;
     }
 


### PR DESCRIPTION
In order to protect the evaluator from causing 500 errors, a new type of exception was introduced and it is caught and converted into a recoverable exception.

This ensures that an invalid mapping or a faulty payload won't crash the application, but a 520 is returned instead.