### PR TITLE
Feature: Return message summary if it contains UTF8 characters

### DIFF
--- a/Components/WebService/Rest/Middleware.php
+++ b/Components/WebService/Rest/Middleware.php
@@ -57,7 +57,7 @@ class Middleware
             $summary = mb_substr($summary, 0, self::$truncateResponseSize).' (truncated...)';
         }
 
-        if (preg_match('/[^\pL\pM\pN\pP\pS\pZ\n\r\t]/', $summary)) {
+        if (preg_match('/[^\pL\pM\pN\pP\pS\pZ\n\r\t]/u', $summary)) {
             return null;
         }
 

--- a/Tests/Unit/Components/WebService/Rest/MiddlewareTest.php
+++ b/Tests/Unit/Components/WebService/Rest/MiddlewareTest.php
@@ -68,6 +68,9 @@ class MiddlewareTest extends TestCase
             ],
             'Truncated_at_135' => [
                 $response, $truncatedAt135, 135
+            ],
+            'With UTF8 characters' => [
+                '’é€௵ဪ‱', '’é€௵ဪ‱', 0
             ]
         ];
     }


### PR DESCRIPTION
I've noticed that if a request throws an exception and if the response body includes the character `’`, the function `get_message_body_summary()` **will return null**.

The expected result should be the string including **the special character**.

This happens due to the regex used to match any printable character lacks of the `/u` flag.

For example, this returns `1`, forcing `get_message_body_summary()` to return `null`:
```
preg_match('/[^\pL\pM\pN\pP\pS\pZ\n\r\t]/', '’')
```

Other multibyte characters like ௵ and ဪ also trigger this issue.

Adding the `/u` flag solves this issue.