### PR TITLE
Feature: Allow empty recipient lists.

### DIFF
--- a/Core/Processors/Routing/RecipientList.php
+++ b/Core/Processors/Routing/RecipientList.php
@@ -126,7 +126,7 @@ class RecipientList extends Processor
             );
         }
 
-        $uris = \explode($this->delimiter, $recipientList);
+        $uris = \preg_split('/' . preg_quote($this->delimiter) . '/', $recipientList, -1, PREG_SPLIT_NO_EMPTY);
 
         foreach ($uris as $uri) {
             switch ($this->aggregationStrategy) {

--- a/Tests/Unit/Core/Processors/Routing/RecipientListTest.php
+++ b/Tests/Unit/Core/Processors/Routing/RecipientListTest.php
@@ -203,7 +203,7 @@ class RecipientListTest extends TestCase
             ->method('getId');
 
         $expression = "exchange.getHeader('recipientList')";
-        $recipientList = 'route_a,route_b';
+        $recipientList = '';
 
         $evaluator = $this->createMock(ExpressionEvaluator::class);
         $evaluator

--- a/Tests/Unit/Core/Processors/Routing/RecipientListTest.php
+++ b/Tests/Unit/Core/Processors/Routing/RecipientListTest.php
@@ -71,7 +71,7 @@ class RecipientListTest extends TestCase
         $this->expectException(ProcessingException::class);
 
         $expression = 'not good expression';
-        $exchange  = $this->createMock(Exchange::class);
+        $exchange = $this->createMock(Exchange::class);
 
         $evaluator = $this->createMock(ExpressionEvaluator::class);
         $evaluator
@@ -122,7 +122,7 @@ class RecipientListTest extends TestCase
             ->will($this->returnValue('123'));
 
         $expression = "exchange.getHeader('recipientList')";
-        $recipientList = 'route_a,route_b';
+        $recipientList = 'route_a!route_b';
 
         $evaluator = $this->createMock(ExpressionEvaluator::class);
         $evaluator
@@ -146,7 +146,7 @@ class RecipientListTest extends TestCase
 
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
-        $this->recipientList->setDelimiter(',');
+        $this->recipientList->setDelimiter('!');
         $this->recipientList->setExpression($expression);
         $this->recipientList->setAggregationStrategy(RecipientList::AGGREGATION_STRATEGY_FIRE_AND_FORGET);
         $this->recipientList->setEvaluator($evaluator);
@@ -170,5 +170,83 @@ class RecipientListTest extends TestCase
         $this->recipientList->process($exchange);
 
         $this->assertSame(2, $dispatchedEventsCounter);
+    }
+
+    public function testItShouldAcceptEmptyRecipientLists()
+    {
+        $context = $this->createMock(Context::class);
+        $context
+            ->expects($this->any())
+            ->method('get')
+            ->with($this->equalTo('version'))
+            ->will($this->returnValue(1));
+
+        $message = $this->createMock(MessageInterface::class);
+        $message
+            ->expects($this->any())
+            ->method('getContext')
+            ->will($this->returnValue($context));
+
+        // No interaction with the exchange
+        $exchange = $this->createMock(Exchange::class);
+        $exchange
+            ->expects($this->never())
+            ->method('getIn');
+        $exchange
+            ->expects($this->never())
+            ->method('getItinerary');
+        $exchange
+            ->expects($this->never())
+            ->method('getHeaders');
+        $exchange
+            ->expects($this->never())
+            ->method('getId');
+
+        $expression = "exchange.getHeader('recipientList')";
+        $recipientList = 'route_a,route_b';
+
+        $evaluator = $this->createMock(ExpressionEvaluator::class);
+        $evaluator
+            ->expects($this->once())
+            ->method('evaluateWithExchange')
+            ->with($this->equalTo($expression), $this->equalTo($exchange))
+            ->will($this->returnValue($recipientList));
+
+        $itineraryParams = ['_itinerary' => $this->createMock(Itinerary::class)];
+
+        // No interaction with the itinerary resolver
+        $itineraryResolver = $this->createMock(ItineraryResolver::class);
+        $itineraryResolver
+            ->expects($this->never())
+            ->method('getItineraryParams');
+        $itineraryResolver
+            ->expects($this->never())
+            ->method('filterItineraryParamsToPropagate');
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $this->recipientList->setDelimiter(',');
+        $this->recipientList->setExpression($expression);
+        $this->recipientList->setAggregationStrategy(RecipientList::AGGREGATION_STRATEGY_FIRE_AND_FORGET);
+        $this->recipientList->setEvaluator($evaluator);
+        $this->recipientList->setItineraryResolver($itineraryResolver);
+        $this->recipientList->setEventDispatcher($eventDispatcher);
+
+        // No events should be dispatched if the list is empty
+        $exchangeEvents = false;
+        $eventDispatcher
+            ->expects($this->any())
+            ->method('dispatch')
+            ->with(($this->callback(function ($eventName) use($exchangeEvents){
+                if (NewExchangeEvent::TYPE_NEW_EXCHANGE_EVENT === $eventName) {
+                    return false;
+                }
+
+                return true;
+            })));
+
+        $this->recipientList->process($exchange);
+
+        $this->assertFalse($exchangeEvents, 'Exchange event was dispatched with an empty recipient list.');
     }
 }


### PR DESCRIPTION
This allows users to define a set of target systems + recipient list (**with no fixed targets**).

For example, you have broadcast flow with 3 targets, one inside the recipient list:

* target A
* target B
* recipient list (with target C)

If target C is not interested in the payload, recipient list **will be empty**. Without this fix, IFB tries to find a processor named `v9999-` and errors out.

Function splitting the recipient list (`explode`) had to be swapped out for `preg_split`. `explode` always returns an array (even if you explode an empty string). `preg_split` has the same functionality but allows you to set a flag to return an empty array if nothing matches.