### PR TITLE
feature/updateVmsMapping: Removing mergeArraysByKeyValue as is not used anymore

### DIFF
--- a/Tools/Mapper/Mapper.php
+++ b/Tools/Mapper/Mapper.php
@@ -434,41 +434,4 @@ class Mapper implements MapperInterface
         return false;
     }
 
-    /**
-     * Will merge multidimensional arrays based on a matching child element value
-     *
-     * Mappings Accepted Values: 'coupled', 'standard'
-     * standard: will merge any item with the elementIdentifier
-     * coupled: will merge an item with the elementIdentifier along with the item right below it
-     *
-     * @param array $parentArray
-     * @param string $elementIdentifier
-     * @param array $mappings
-     *
-     * @return array
-     */
-    function mergeArraysByKeyValue(array $parentArray, string $elementIdentifier, array $mappings = [])
-    {
-        $mergedArray = [];
-        foreach ($parentArray as $childKey => $childArray) {
-            foreach ($childArray as $elementKey => $element) {
-                if (isset($mappings['coupled']) && in_array($childKey, $mappings['coupled'], true)) {
-                    if (isset($element[$elementIdentifier])) {
-                        $mergedArray[$element[$elementIdentifier]][$childKey] = [$element, $childArray[$elementKey + 1]];
-                    }
-                    continue;
-                }
-
-                if (!isset($element[$elementIdentifier])) {
-                    continue;
-                }
-
-                if (isset($mappings['standard']) && in_array($childKey, $mappings['standard'], true)) {
-                    $mergedArray[$element[$elementIdentifier]][$childKey][] = $element;
-                }
-            }
-        }
-
-        return $mergedArray;
-    }
 }


### PR DESCRIPTION
Removing Pull Request: https://github.com/smartboxgroup/integration-framework-bundle/pull/138

 The function `mergeArraysByKeyValue` was added to map the target system with an unexpected response format but is not needed anymore.