### PR TITLE
MINT-9672: Add mergeMapping function to Tools/Mapper

### DIFF
--- a/Tools/Mapper/Mapper.php
+++ b/Tools/Mapper/Mapper.php
@@ -90,6 +90,50 @@ class Mapper implements MapperInterface
     }
 
     /**
+     * Merge multiples arrays values in a single mappingName
+     *
+     * @param string $mappingName
+     * @param array<array{mapFunction: string, object: array|null, context: string}> $mappers
+     *
+     * @return null|string
+     */
+    public function mergeMapping($mappingName, $mappers)
+    {
+        $response = [];
+
+        if (empty($mappers)) {
+            throw new \InvalidArgumentException('No mapper provided.');
+        }
+
+        foreach ($mappers as $mapper){
+            $mapFunction = $mapper[0] ?? null;
+            $object = $mapper[1] ?? null;
+            $context = $mapper[2] ?? null;
+
+            if(empty($object)){
+                continue;
+            }
+
+            if(empty($mapFunction) || empty($context)){
+                throw new \InvalidArgumentException('No mapper function or context informed');
+            }
+
+            switch ($mapFunction){
+                case 'map':
+                    $response[] = $this->map($object, $mappingName, $context);
+                    break;
+                case 'mapAll':
+                    $response = array_merge($response, $this->mapAll($object, $mappingName, $context));
+                    break;
+                default:
+                    throw new \InvalidArgumentException(sprintf('Invalid mapping name "%s"', $mappingName));
+            }
+        }
+
+        return $response;
+    }
+
+    /**
      * @param $mapping
      * @param $obj
      * @param $context


### PR DESCRIPTION
This change adds a new helper function in the Tools/Mapper/Mapper class, which merges results from the `map()` and `mapAll()` functions into a given mapper.

Usage:
```
media: "obj['gallery'] ? mapper.mergeMapping('single_media_from_catalog', [
  ['map', obj['gallery']['packshot'], 'packshot'],
  ['map', obj['gallery']['eRetail']['main'], 'eRetail'],
  ['map', obj['gallery']['map'], 'map'],
  ['mapAll', obj['gallery']['eRetail']['nonBrand'], 'eRetailerNonBrand']
]) : null"
```