### PR TITLE
MINT-9526: Add mergeMapping function to Tools/Mapper

### DIFF
--- a/Tests/Unit/Tools/Mapper/MapperTest.php
+++ b/Tests/Unit/Tools/Mapper/MapperTest.php
@@ -269,19 +269,17 @@ class MapperTest extends \PHPUnit\Framework\TestCase
         yield 'Wrong type' => [null, null, $ctx];
     }
 
-    public function testShouldMergeMappings()
+    /**
+     * @dataProvider provideMergeMappings
+     */
+    public function testShouldMergeMappings($expectedResult, $mockedMapFunction, $mockedMapAllFunction)
     {
-        $expectedResult = [
-            ['name' => 'packshot', 'location' => 'https://media.com/1'],
-            ['name' => 'eRetailerNonBrand', 'location' => 'https://media.com/2'],
-            ['name' => 'eRetailerNonBrand', 'location' => 'https://media.com/3']
-        ];
         $mapperMock = $this->getMockBuilder(Mapper::class)
             ->setMethods(['mapAll', 'map'])
             ->getMock();
 
-        $mapperMock->method('map')->willReturn(['name' => 'packshot', 'location' => 'https://media.com/1']);
-        $mapperMock->method('mapAll')->willReturn([['name' => 'eRetailerNonBrand', 'location' => 'https://media.com/2'],['name' => 'eRetailerNonBrand', 'location' => 'https://media.com/3']]);
+        $mapperMock->method('map')->willReturn($mockedMapFunction);
+        $mapperMock->method('mapAll')->willReturn($mockedMapAllFunction);
 
         $result = $mapperMock->mergeMapping('mappingName', [
             ['map', ['https://media.com/1'], 'packshot'],
@@ -289,6 +287,34 @@ class MapperTest extends \PHPUnit\Framework\TestCase
         ]);
 
         $this->assertSame($expectedResult, $result);
+    }
+
+    public function provideMergeMappings()
+    {
+        yield 'Merge mappings' => [
+            [
+                ['name' => 'packshot', 'location' => 'https://media.com/1'],
+                ['name' => 'eRetailerNonBrand', 'location' => 'https://media.com/2'],
+                ['name' => 'eRetailerNonBrand', 'location' => 'https://media.com/3']
+            ],
+            ['name' => 'packshot', 'location' => 'https://media.com/1'],
+            [['name' => 'eRetailerNonBrand', 'location' => 'https://media.com/2'],['name' => 'eRetailerNonBrand', 'location' => 'https://media.com/3']]
+        ];
+        yield 'Merge mappings with null map' => [
+            [
+                ['name' => 'eRetailerNonBrand', 'location' => 'https://media.com/2'],
+                ['name' => 'eRetailerNonBrand', 'location' => 'https://media.com/3']
+            ],
+            null,
+            [['name' => 'eRetailerNonBrand', 'location' => 'https://media.com/2'],['name' => 'eRetailerNonBrand', 'location' => 'https://media.com/3']]
+        ];
+        yield 'Merge mappings with null mapAll' => [
+            [
+                ['name' => 'packshot', 'location' => 'https://media.com/1']
+            ],
+            ['name' => 'packshot', 'location' => 'https://media.com/1'],
+            null
+        ];
     }
 
     /**

--- a/Tools/Mapper/Mapper.php
+++ b/Tools/Mapper/Mapper.php
@@ -90,6 +90,50 @@ class Mapper implements MapperInterface
     }
 
     /**
+     * Merge multiples arrays values in a single mappingName
+     *
+     * @param string $mappingName
+     * @param array<array{mapFunction: string, object: array|null, context: string}> $mappers
+     *
+     * @return null|string
+     */
+    public function mergeMapping($mappingName, $mappers)
+    {
+        $response = [];
+
+        if (empty($mappers)) {
+            throw new \InvalidArgumentException('No mapper provided.');
+        }
+
+        foreach ($mappers as $mapper){
+            $mapFunction = $mapper[0] ?? null;
+            $object = $mapper[1] ?? null;
+            $context = $mapper[2] ?? null;
+
+            if(empty($object)){
+                continue;
+            }
+
+            if(empty($mapFunction) || empty($context)){
+                throw new \InvalidArgumentException('No mapper function or context informed');
+            }
+
+            switch ($mapFunction){
+                case 'map':
+                    $response[] = $this->map($object, $mappingName, $context);
+                    break;
+                case 'mapAll':
+                    $response = array_merge($response, $this->mapAll($object, $mappingName, $context));
+                    break;
+                default:
+                    throw new \InvalidArgumentException(sprintf('Invalid mapping name "%s"', $mappingName));
+            }
+        }
+
+        return $response;
+    }
+
+    /**
      * @param $mapping
      * @param $obj
      * @param $context

--- a/Tools/Mapper/Mapper.php
+++ b/Tools/Mapper/Mapper.php
@@ -99,11 +99,11 @@ class Mapper implements MapperInterface
      */
     public function mergeMapping($mappingName, $mappers)
     {
-        $response = [];
-
         if (empty($mappers)) {
             throw new \InvalidArgumentException('No mapper provided.');
         }
+
+        $response = [];
 
         foreach ($mappers as $mapper){
             $mapFunction = $mapper[0] ?? null;
@@ -114,19 +114,15 @@ class Mapper implements MapperInterface
                 continue;
             }
 
-            if(empty($mapFunction) || empty($context)){
+            if(empty($mapFunction) || empty($context) || !in_array($mapFunction, ['map', 'mapAll'])){
                 throw new \InvalidArgumentException('No mapper function or context informed');
             }
 
-            switch ($mapFunction){
-                case 'map':
-                    $response[] = $this->map($object, $mappingName, $context);
-                    break;
-                case 'mapAll':
-                    $response = array_merge($response, $this->mapAll($object, $mappingName, $context));
-                    break;
-                default:
-                    throw new \InvalidArgumentException(sprintf('Invalid mapping name "%s"', $mappingName));
+            $mappedObject = $this->$mapFunction($object, $mappingName, $context);
+            if (!empty($mappedObject)) {
+                $response = ($mapFunction === 'map')
+                    ? array_merge($response, [$mappedObject])
+                    : array_merge($response, $mappedObject);
             }
         }
 

--- a/Tools/Mapper/Mapper.php
+++ b/Tools/Mapper/Mapper.php
@@ -92,13 +92,18 @@ class Mapper implements MapperInterface
     /**
      * Merge multiples arrays values in a single mappingName
      *
+     * @param array $elements
      * @param string $mappingName
      * @param array<array{mapFunction: string, object: array|null, context: string}> $mappers
      *
      * @return null|string
      */
-    public function mergeMapping($mappingName, $mappers)
+    public function mergeMapping($elements, $mappingName, $mappers)
     {
+        if(empty($elements)) {
+            return null;
+        }
+
         if (empty($mappers)) {
             throw new \InvalidArgumentException('No mapper provided.');
         }
@@ -106,13 +111,13 @@ class Mapper implements MapperInterface
         $response = [];
 
         foreach ($mappers as $mapper){
-            $mapFunction = $mapper[0] ?? null;
-            $object = $mapper[1] ?? null;
-            $context = $mapper[2] ?? null;
-
+            $object = $this->getObject($elements, $mapper[1]);
             if(empty($object)){
                 continue;
             }
+
+            $mapFunction = $mapper[0] ?? null;
+            $context = $mapper[2] ?? $mapper[1] ?? null;
 
             if(empty($mapFunction) || empty($context) || !in_array($mapFunction, ['map', 'mapAll'])){
                 throw new \InvalidArgumentException('No mapper function or context informed');
@@ -127,6 +132,21 @@ class Mapper implements MapperInterface
         }
 
         return $response;
+    }
+
+
+    private function getObject(array $elements, string $path) {
+        $keys = explode('.', $path);
+        $current = $elements;
+
+        foreach ($keys as $key) {
+            if (!isset($current[$key])) {
+                return null;
+            }
+            $current = $current[$key];
+        }
+
+        return $current;
     }
 
     /**


### PR DESCRIPTION
This change adds a new helper function in the Tools/Mapper/Mapper class, which merges results from the `map()` and `mapAll()` functions into a given mapper.

Usage:
```
media: "obj['gallery'] ? mapper.mergeMapping('single_media_from_catalog', [
  ['map', obj['gallery']['packshot'], 'packshot'],
  ['map', obj['gallery']['eRetail']['main'], 'eRetail'],
  ['map', obj['gallery']['map'], 'map'],
  ['mapAll', obj['gallery']['eRetail']['nonBrand'], 'eRetailerNonBrand']
]) : null"
```